### PR TITLE
further fixes for BYTEMAN-174

### DIFF
--- a/agent/src/main/java/org/jboss/byteman/agent/adapter/cfg/BBlock.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/adapter/cfg/BBlock.java
@@ -163,9 +163,14 @@ public class BBlock
             monitorEnters.push(new CodeLocation(this, index));
         } else if (instruction == Opcodes.MONITOREXIT) {
             CodeLocation exit = new CodeLocation(this, index);
-            // we need to keep track of exits
+            // we need to keep track of exits for when we can collate monitor section ends
+            // with try catch blocks which overlapthis block so we don't drop them here
+            // even if there is a matching enter in this block
             monitorExits.add(exit);
-            // if there is an enter in this block then it belongs to this one so pop it and record the pairing
+            // however if there is an enter in this block then it belongs to this exit
+            // so we pop it to ensurewe only retain active local enters
+            // we also record the pairing so we can work back from the matched exit to
+            //its enter. pairing with non-local enters is done at block end carry forward
             if (!monitorEnters.isEmpty()) {
                 CodeLocation enter = monitorEnters.pop();
                 cfg.addMonitorPair(enter, exit);


### PR DESCRIPTION
the previous change factored open monitor computation into a utility routine which was used during trigger insertion and during open monitor carry forward performed at block end.Unfortunately,the factored code included pairing local enters and exits as a side effect. This meant that calling it at trigger inject sometimes led to incorrect computation of open monitors at carry forward. This has been fixed by adding an extra test to detect and allow for previously noted local pairings.
