### PR TITLE
[BYTEMAN-263] Dtest Intrumentator.injectOnCall to work with interfaces (not just classes)

### DIFF
--- a/contrib/dtest/src/org/jboss/byteman/contrib/dtest/Instrumentor.java
+++ b/contrib/dtest/src/org/jboss/byteman/contrib/dtest/Instrumentor.java
@@ -195,7 +195,13 @@ public class Instrumentor
         String ruleName = this.getClass().getCanonicalName()+"_"+className+"_"+methodName+"_injectionat"+where;
 
         RuleBuilder ruleBuilder = new RuleBuilder(ruleName);
-        ruleBuilder.onClass(className).inMethod(methodName).at(where);
+        if(clazz.isInterface()) 
+        {
+            ruleBuilder.onInterface(className);
+        } else {
+            ruleBuilder.onClass(className);
+        }
+        ruleBuilder.inMethod(methodName).at(where);
         ruleBuilder.usingHelper(BytemanTestHelper.class);
         ruleBuilder.when(condition).doAction(action);
 


### PR DESCRIPTION
Currently the dtest Instrumentator for cal injectOnCall (and similar) method works just with class (it is able to add keyword CLASS to the byteman rule). This change adding check whether the instrumented instance is interface and in such case the INTERFACE keyword is used.
