### PR TITLE
BYTEMAN-255 : One more chance to identify the test JVM process during agent load...

### DIFF
--- a/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnit.java
+++ b/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnit.java
@@ -8,6 +8,7 @@ import org.jboss.byteman.agent.submit.ScriptText;
 import org.jboss.byteman.agent.submit.Submit;
 
 import java.io.*;
+import java.lang.management.ManagementFactory;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -203,6 +204,18 @@ public class BMUnit
                     break;
                 }
             }
+			
+			// for case we don't get any availableVMs
+			// try to get the current process ID
+			if (id == null) {
+                String processName = ManagementFactory.getRuntimeMXBean().getName();
+				if (processName != null && processName.contains("@")) {
+					try {
+						id = Integer.valueOf(processName.substring(0, processName.indexOf("@"))).toString();
+					} catch (Exception e) {}
+				}
+            }
+			
             // make sure we found a process
             if (id == null) {
                 throw new Exception("BMUnit : Unable to identify test JVM process during agent load");


### PR DESCRIPTION
See https://issues.jboss.org/browse/BYTEMAN-255
It solves the issue for cases we don't get any availableVMs on Windows (VirtualMachine.list() is empty) with a different method to get the current process ID...

java.lang.Exception: BMUnit : Unable to identify test JVM process during agent load

java -version
java version "1.7.0_17"
Java(TM) SE Runtime Environment (build 1.7.0_17-b02)
Java HotSpot(TM) 64-Bit Server VM (build 23.7-b01, mixed mode)

mvn -version
Apache Maven 3.1.1 (0728685237757ffbf44136acec0402957f723d9a; 2013-09-17 17:22:22+0200)
Maven home: D:\Outils\Maven\apache-maven-3.1.1\bin\..
Java version: 1.7.0_17, vendor: Oracle Corporation
Java home: C:\Program Files\Java\jdk1.7.0_17\jre
Default locale: fr_FR, platform encoding: Cp1252
OS name: "windows 7", version: "6.1", arch: "amd64", family: "windows"