### PR TITLE
Added rendezvous() method which accepts a timeout (in ms) (https://issue...

### DIFF
--- a/agent/src/main/java/org/jboss/byteman/rule/helper/Helper.java
+++ b/agent/src/main/java/org/jboss/byteman/rule/helper/Helper.java
@@ -656,11 +656,22 @@ public class Helper
      */
     public int rendezvous(Object identifier)
     {
+        return rendezvous(identifier, 0);
+    }
+
+    /**
+     *
+     * @param identifier
+     * @param millis
+     * @return
+     */
+    public int rendezvous(Object identifier, long millis)
+    {
         Rendezvous rendezvous = rendezvousMap.get(identifier);
 
         if (rendezvous !=  null) {
             synchronized(rendezvous) {
-                int result = rendezvous.rendezvous();
+                int result = rendezvous.rendezvous(millis);
                 // make sure the rendezvous is removed from the map if required
                 // n.b. this implementation makes sure the remove happens before any thread
                 // successfully passes the rendezvous call


### PR DESCRIPTION
Adds a rendezvous(Object, long millis) parameter which accepts a timeout. A value <= 0 blocks forever, any value greater than 0 times out. When this happens, an ExecuteException is thrown so that a unit test will fail.
https://issues.jboss.org/browse/BYTEMAN-258
