### PR TITLE
BYTEMAN-296 - NPE thrown because type is null in some situations

### DIFF
--- a/agent/src/main/java/org/jboss/byteman/agent/adapter/cfg/CFG.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/adapter/cfg/CFG.java
@@ -1701,9 +1701,10 @@ public class CFG
             }
             // handlers planted by previous transforms will not be tagged but will be for a byteman exception type
             String typeName = details.getType();
-            if (typeName.equals(CFG.EARLY_RETURN_EXCEPTION_TYPE_NAME) ||
+            if (typeName != null && (
+                    typeName.equals(CFG.EARLY_RETURN_EXCEPTION_TYPE_NAME) ||
                     typeName.equals(CFG.EXECUTE_EXCEPTION_TYPE_NAME) ||
-                    typeName.equals(CFG.THROW_EXCEPTION_TYPE_NAME)) {
+                    typeName.equals(CFG.THROW_EXCEPTION_TYPE_NAME))) {
                 return true;
             }
         }


### PR DESCRIPTION
See https://issues.jboss.org/browse/BYTEMAN-296