### PR TITLE
Add inclusion and exclusion list support

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -584,6 +584,66 @@
                          <argLine>-javaagent:${project.build.directory}/byteman-${project.version}.jar=script:${project.build.testOutputDirectory}/scripts/misc/TestTriggerClassMethodBinding.btm</argLine>
                       </configuration>
                     </execution>
+                    <execution>
+                        <id>misc.TestIncludeExclude-INCLUDED</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <includes>
+                                <include>org/jboss/byteman/tests/misc/TestIncludeExclude.class</include>
+                            </includes>
+                            <argLine>-Dbyteman.included=misc.TestIncludeExclude -Dtestcase=INCLUDED -javaagent:${project.build.directory}/byteman-${project.version}.jar=script:${project.build.testOutputDirectory}/scripts/misc/TestIncludeExclude.btm</argLine>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>misc.TestIncludeExclude-NOT_INCLUDED</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <includes>
+                                <include>org/jboss/byteman/tests/misc/TestIncludeExclude.class</include>
+                            </includes>
+                            <argLine>-Dbyteman.included=misc.Other -Dtestcase=NOT_INCLUDED -javaagent:${project.build.directory}/byteman-${project.version}.jar=script:${project.build.testOutputDirectory}/scripts/misc/TestIncludeExclude.btm</argLine>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>misc.TestIncludeExclude-EXCLUDED</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <includes>
+                                <include>org/jboss/byteman/tests/misc/TestIncludeExclude.class</include>
+                            </includes>
+                            <argLine>-Dbyteman.excluded=misc.TestIncludeExclude -Dtestcase=EXCLUDED -javaagent:${project.build.directory}/byteman-${project.version}.jar=script:${project.build.testOutputDirectory}/scripts/misc/TestIncludeExclude.btm</argLine>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>misc.TestIncludeExclude-NOT_EXCLUDED</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <includes>
+                                <include>org/jboss/byteman/tests/misc/TestIncludeExclude.class</include>
+                            </includes>
+                            <argLine>-Dbyteman.excluded=misc.Other -Dtestcase=NOT_EXCLUDED -javaagent:${project.build.directory}/byteman-${project.version}.jar=script:${project.build.testOutputDirectory}/scripts/misc/TestIncludeExclude.btm</argLine>
+                        </configuration>
+                    </execution>
                     <!--
                     <execution>
                       <id>misc.TestDowncast</id>

--- a/agent/src/main/java/org/jboss/byteman/agent/Transformer.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/Transformer.java
@@ -23,26 +23,26 @@
 */
 package org.jboss.byteman.agent;
 
-import org.jboss.byteman.agent.adapter.*;
-import org.jboss.byteman.agent.check.ClassChecker;
-import org.jboss.byteman.agent.check.LoadCache;
-import org.jboss.byteman.modules.ModuleSystem;
-import org.jboss.byteman.rule.Rule;
-import org.jboss.byteman.rule.type.TypeHelper;
-import org.jboss.byteman.rule.exception.ParseException;
-import org.jboss.byteman.rule.exception.TypeException;
-import org.objectweb.asm.*;
-
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
 import java.security.Policy;
 import java.security.ProtectionDomain;
-import java.util.*;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jboss.byteman.agent.check.ClassChecker;
+import org.jboss.byteman.agent.check.LoadCache;
+import org.jboss.byteman.modules.ModuleSystem;
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.type.TypeHelper;
 
 /**
  * byte code transformer used to introduce byteman events into JBoss code
@@ -219,7 +219,7 @@ public class Transformer implements ClassFileTransformer {
             // but we exclude byteman classes and java.lang classes
             String internalName = TypeHelper.internalizeClass(className);
 
-            if (isBytemanClass(internalName) || !isTransformable(internalName)) {
+            if (isBytemanClass(internalName) || !isTransformable(internalName)  || !isIncluded(internalName) || isExcluded(internalName)) {
                 return null;
             }
 
@@ -1240,6 +1240,60 @@ public class Transformer implements ClassFileTransformer {
 
     private static boolean computeDisallowDowncast() {
         return (System.getProperty(DISALLOW_DOWNCAST) != null);
+    }
+
+    List<String> included = readCollectionProperty("byteman.included");
+
+    List<String> excluded = readCollectionProperty("byteman.excluded");
+
+    /**
+     * Read a comma separated system property
+     * 
+     * @param name  property name
+     *              
+     * @return  a List of String values
+     */
+    List<String> readCollectionProperty(String name) {
+        List<String> list = new ArrayList<String>();
+        for (String s : System.getProperty(name, "").split(",")) {
+            s = s.trim();
+            if (s.length() > 0) list.add(s);
+        }
+        return list;
+    }
+
+    /**
+     * Test if class has been configured as excluded
+     * 
+     * @param internalName  the class name to test
+     *                      
+     * @return  false if no exclusion is defined or classname not in exclusion list
+     */
+    private boolean isExcluded(String internalName) {
+        
+        // If no exclusion is configured, always return false
+        if (excluded.size() == 0) return false;
+        
+        // Iterate on exclusions
+        for (String s : excluded) {
+            if (internalName.contains(s)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Test if class has been configured as included
+     * 
+     * @param internalName  the class name to test
+     *                      
+     * @return  true if no inclusion configured or classname in inclusion list
+     */
+    private boolean isIncluded(String internalName) {
+        if (included.size() == 0) return true;
+        for (String s : included) {
+            if (internalName.contains(s)) return true;
+        }
+        return false;
     }
 
     private void checkConfiguration(String property)

--- a/agent/src/test/java/org/jboss/byteman/tests/misc/TestIncludeExclude.java
+++ b/agent/src/test/java/org/jboss/byteman/tests/misc/TestIncludeExclude.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ * @authors Andrew Dinn
+ */
+
+package org.jboss.byteman.tests.misc;
+
+import org.jboss.byteman.tests.Test;
+
+/**
+ * class to test use of downcast in rule binding
+ */
+public class TestIncludeExclude extends Test
+{
+    public TestIncludeExclude()
+    {
+        super(TestIncludeExclude.class.getCanonicalName());
+    }
+
+    public void test()
+    {
+        log("calling TestIncludeExclude.sayHello()");
+        sayHello();
+        log("called TestIncludeExclude.sayHello()");
+
+        checkOutput(true);
+    }
+    
+    private void sayHello() {
+        log("Hello !");
+    }
+
+    @Override
+    public String getExpected() {
+        String testcase = System.getProperty("testcase");
+        
+        if ("INCLUDED".equals(testcase) || "NOT_EXCLUDED".equals(testcase)) {
+            logExpected("calling TestIncludeExclude.sayHello()");
+            logExpected("Hello !");
+            logExpected("CU later...");
+            logExpected("called TestIncludeExclude.sayHello()");
+        }
+        else if ("EXCLUDED".equals(testcase) || "NOT_INCLUDED".equals(testcase)) {
+            logExpected("calling TestIncludeExclude.sayHello()");
+            logExpected("Hello !");
+            logExpected("called TestIncludeExclude.sayHello()");
+        }
+
+        return super.getExpected();
+    }
+}

--- a/agent/src/test/resources/scripts/misc/TestIncludeExclude.btm
+++ b/agent/src/test/resources/scripts/misc/TestIncludeExclude.btm
@@ -1,0 +1,36 @@
+##############################################################################
+# JBoss, Home of Professional Open Source
+# Copyright 2012, Red Hat and individual contributors
+# by the @authors tag. See the copyright.txt in the distribution for a
+# full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+# @authors Andrew Dinn
+#
+
+##############################################################################
+#
+# test that a downcast can be used in a rule binding
+
+RULE test include exclude
+CLASS org.jboss.byteman.tests.misc.TestIncludeExclude
+METHOD sayHello
+AT EXIT
+BIND test = $0
+IF TRUE
+DO test.log("CU later...");
+ENDRULE

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                   <attach>true</attach>
+                  <failOnError>false</failOnError>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
I've added the possibility to define inclusion and exclusion list as system properties :+1: 

-Dbyteman.excluded=misc.Other,misc.anotherOne
-Dbyteman.included=misc.Other,misc.anotherOne

I've added integration tests for all situations. We had to code this stuff because we were confronted to heavy classloading events. (detected with profiling tool)

Thanks in advance for your feedback