### PR TITLE
Fix agent jar lookup when system property is used.

### DIFF
--- a/install/src/main/java/org/jboss/byteman/agent/install/Install.java
+++ b/install/src/main/java/org/jboss/byteman/agent/install/Install.java
@@ -288,8 +288,8 @@ public class Install
     }
 
     /**
-     * check for environment setting BYTEMAN_HOME and use it to identify the location of
-     * the byteman agent jar.
+     * Check for system property org.jboss.byteman.home in preference to the environment setting
+     * BYTEMAN_HOME and use it to identify the location of the byteman agent jar.
      */
     private void locateAgent() throws IOException
     {
@@ -298,11 +298,11 @@ public class Install
         String bmHome = System.getProperty(BYTEMAN_HOME_SYSTEM_PROP);
         if (bmHome == null || bmHome.length() == 0) {
             bmHome = System.getenv(BYTEMAN_HOME_ENV_VAR);
-            if (bmHome == null || bmHome.length() == 0 || bmHome.equals("null")) {
-                locateAgentFromClasspath();
-            } else {
-                locateAgentFromHomeDir(bmHome);
-            }
+        }
+        if (bmHome == null || bmHome.length() == 0 || bmHome.equals("null")) {
+            locateAgentFromClasspath();
+        } else {
+            locateAgentFromHomeDir(bmHome);
         }
     }
 


### PR DESCRIPTION
Instead of skipping to set the agentJar instance variable via
locateAgentFromHomeDir(bmHome) go down the same branch as if
the ENV variable was used.

Resolves BYTEMAN-303