### PR TITLE
Make install/submit usable as OSGi bundles.

### DIFF
--- a/install/pom.xml
+++ b/install/pom.xml
@@ -24,7 +24,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>byteman-install</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <description>
         The Byteman install jar contains classes to install the Byteman agent into the current JVM
         or a remote JVM
@@ -56,5 +56,21 @@
           </dependencies>
         </profile>
     </profiles>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+          <configuration>
+            <instructions>
+              <Export-Package>org.jboss.byteman.agent.install</Export-Package>
+              <Bundle-SymbolicName>org.jboss.byteman.agent.install</Bundle-SymbolicName>
+              <_noee>true</_noee> <!-- Do not generate Require-Capability header -->
+            </instructions>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/submit/pom.xml
+++ b/submit/pom.xml
@@ -24,7 +24,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>byteman-submit</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <description>
         The Byteman install jar contains classes whcih canbe used to install an agent into the
         current JVM or into a remote JVM
@@ -35,4 +35,20 @@
         <artifactId>byteman-root</artifactId>
         <version>3.0.4-SNAPSHOT</version>
     </parent>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+          <configuration>
+            <instructions>
+              <Export-Package>org.jboss.byteman.agent.submit</Export-Package>
+              <Bundle-SymbolicName>org.jboss.byteman.agent.submit</Bundle-SymbolicName>
+              <_noee>true</_noee> <!-- Do not generate Require-Capability header -->
+            </instructions>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Add maven-bundle-plugin instructions so as to generate
minimal OSGi MANIFEST metadata.

All packages in both jars are exported.

Resolves BYTEMAN-305.