### PR TITLE
Enhancement of dtest instrumentation tooling

### DIFF
--- a/contrib/dtest/src/org/jboss/byteman/contrib/dtest/InstrumentedClass.java
+++ b/contrib/dtest/src/org/jboss/byteman/contrib/dtest/InstrumentedClass.java
@@ -114,6 +114,29 @@ public class InstrumentedClass implements RemoteInterface
     }
 
     /**
+     * Checks that the number of known invocations of the given method is specified count.
+     *
+     * @param message the message to print in case of assertion failure.
+     * @param methodName the method name to look for.
+     * @param callCount the expected number of the invocation count.
+     */
+    public void assertMethodCallCount(String message, String methodName, int callCount)
+    {
+    	assertMethodCallCount(message, methodName, new CallCount(callCount, callCount));
+    }
+    
+    /**
+     * Checks that the number of known invocations of the given method is specified count.
+     *
+     * @param methodName the method name to look for.
+     * @param callCount the expected number of the invocation count.
+     */
+    public void assertMethodCallCount(String methodName, int callCount)
+    {
+    	assertMethodCallCount(null, methodName, new CallCount(callCount, callCount));
+    }
+
+    /**
      * Checks that the given method has been called at least once on each known instance of the class.
      * Uses junit internally, hence expect the normal exception throwing in case of failure.
      *

--- a/contrib/dtest/src/org/jboss/byteman/contrib/dtest/InstrumentedInstance.java
+++ b/contrib/dtest/src/org/jboss/byteman/contrib/dtest/InstrumentedInstance.java
@@ -89,7 +89,13 @@ public class InstrumentedInstance
     public void assertMethodCallCount(String message, String methodName, CallCount callCount)
     {
         int invocationCount = getInvocationCount(methodName);
-        assertTrue((message == null ? "" : message)+" - required minimum call count "+callCount.getMin()+" but was "+invocationCount, callCount.getMin() <= invocationCount);
-        assertTrue((message == null ? "" : message)+" - required maximum call count "+callCount.getMax()+" but was "+invocationCount, callCount.getMax() >= invocationCount);
+
+        String assertInfo = (message == null ? "" : message + " - ") + String.format("Method %s#%s ", className, methodName);
+        if(callCount.getMin() == callCount.getMax()) {
+        	assertTrue(assertInfo + "required call count " + callCount.getMin() + " but was " + invocationCount, callCount.getMin() == invocationCount);
+        } else {
+        	assertTrue(assertInfo + "required minimum call count " + callCount.getMin() + " but was " + invocationCount, callCount.getMin() <= invocationCount);
+        	assertTrue(assertInfo + "required maximum call count " + callCount.getMax() + " but was " + invocationCount, callCount.getMax() >= invocationCount);
+        }
     }
 }


### PR DESCRIPTION
I'm proposing a enhancement of dtest instrumetnation classes.
This aims to have a possibility to instrument a class which is not directly on classpath of the client.

I would like use it when testing for example EAP app server and do not want to have implementation of an RAR or JDBC driver on test classpath but I would like to know if some method was called on server side.

Then adding a help classes for being able to just say exact number of calls expected being done on a class when asserting instrumentation.