### PR TITLE
Set system property when agent is installed.

### DIFF
--- a/agent/src/main/java/org/jboss/byteman/agent/Main.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/Main.java
@@ -43,6 +43,7 @@ import java.util.jar.JarFile;
 public class Main {
     public static boolean firstTime = true;
     public final static String BYTEMAN_PREFIX = "org.jboss.byteman.";
+    public final static String BYTEMAN_AGENT_LOADED = "org.jboss.byteman.agent.loaded";
 
     public static void premain(String args, Instrumentation inst)
             throws Exception
@@ -51,6 +52,7 @@ public class Main {
         synchronized (Main.class) {
             if (firstTime) {
                 firstTime = false;
+                System.setProperty(BYTEMAN_AGENT_LOADED, Boolean.TRUE.toString());
             } else {
                 throw new Exception("Main : attempting to load Byteman agent more than once");
             }

--- a/install/src/main/java/org/jboss/byteman/agent/install/Install.java
+++ b/install/src/main/java/org/jboss/byteman/agent/install/Install.java
@@ -151,6 +151,25 @@ public class Install
      */
     public static String getSystemProperty(String id, String property)
     {
+        return getProperty(id, property);
+    }
+
+    /**
+     * attach to the virtual machine identified by id and return {@code true} if a Byteman
+     * agent has already been attached to it. id must be the id of a virtual machine
+     * returned by method availableVMs.
+     * @param id the id of the machine to attach to
+     * @return {@code true} if and only if a Byteman agent has already been attached to the
+     * virtual machine.
+     */
+    public static boolean isAgentAttached(String id)
+    {
+        String value = getProperty(id, BYTEMAN_AGENT_LOADED_PROPERTY);
+        return Boolean.parseBoolean(value);
+    }
+
+    private static String getProperty(String id, String property)
+    {
         VirtualMachine vm = null;
         try {
             vm = VirtualMachine.attach(id);
@@ -430,18 +449,6 @@ public class Install
         }
 
 
-        //!! TODO -- find a way for the agent to notify it is already loaded via an agent property
-        /*
-        Properties properties = vm.getAgentProperties();
-
-        System.out.println("agent properties:");
-        for (String name : properties.stringPropertyNames()) {
-            System.out.print("  ");
-            System.out.print(name);
-            System.out.print("=");
-            System.out.println(properties.getProperty(name));
-        }
-        */
     }
 
     /**
@@ -504,6 +511,8 @@ public class Install
     private VirtualMachine vm;
 
     private static final String BYTEMAN_PREFIX="org.jboss.byteman.";
+
+    private static final String BYTEMAN_AGENT_LOADED_PROPERTY = "org.jboss.byteman.agent.loaded";
 
     /**
      * System property used to idenitfy the location of the installed byteman release.


### PR DESCRIPTION
org.jboss.byteman.agent.loaded=true is being set if an agent is loaded.
Provide Java API in Install in order to detect if an agent is loaded.