### PR TITLE
[BYTEMAN-307] Allow the import list to be cleared by using 'IMPORT' alone

### DIFF
--- a/agent/src/main/java/org/jboss/byteman/agent/ScriptRepository.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/ScriptRepository.java
@@ -116,20 +116,34 @@ public class ScriptRepository
                         scriptCompileToBytecode = false;
                         ruleCompileToBytecode = false;
                     }
-                } else if (line.startsWith("IMPORT ")) {
-                    String imp = line.substring(7).trim();
+                } else if (line.startsWith("IMPORT ") || line.equals("IMPORT")) {
+                    String imp = line.substring(6).trim();
                     if (inRule) {
-                        if (targetImports == null)
-                            targetImports = new String[1];
-                        else
-                            targetImports = Arrays.copyOf(targetImports, targetImports.length + 1);
-                        targetImports[targetImports.length - 1] = imp;
+                        if (imp.isEmpty()) {
+                            // remove any globally defined imports
+                            targetImports = new String[0];
+                        } else {
+                            // add to the existing rule imports if any, otherwise the global ones
+                            if (targetImports == null) {
+                                if (defaultImports == null)
+                                    targetImports = new String[1];
+                                else
+                                    targetImports = Arrays.copyOf(defaultImports, defaultImports.length + 1);
+                            } else {
+                                targetImports = Arrays.copyOf(targetImports, targetImports.length + 1);
+                            }
+                            targetImports[targetImports.length - 1] = imp;
+                        }
                     } else {
-                        if (defaultImports == null)
-                            defaultImports = new String[1];
-                        else
-                            defaultImports = Arrays.copyOf(defaultImports, defaultImports.length + 1);
-                        defaultImports[defaultImports.length - 1] = imp;
+                        if (imp.isEmpty())
+                            defaultImports = null;
+                        else {
+                            if (defaultImports == null)
+                                defaultImports = new String[1];
+                            else
+                                defaultImports = Arrays.copyOf(defaultImports, defaultImports.length + 1);
+                            defaultImports[defaultImports.length - 1] = imp;
+                        }
                     }
                 } else if (!inRule) {
                     if (!line.equals("")) {
@@ -171,7 +185,7 @@ public class ScriptRepository
                             targetHelper = defaultHelper;
                         }
                         if (targetImports == null) {
-                            targetImports = defaultImports;
+                            targetImports = (defaultImports != null) ? defaultImports : new String[0];
                         }
                         RuleScript ruleScript = new RuleScript(name, targetClass, isInterface, isOverride, targetMethod, targetHelper, targetImports, targetLocation, nextRule, startNumber, scriptFile, ruleCompileToBytecode);
                         ruleScripts.add(ruleScript);

--- a/agent/src/main/java/org/jboss/byteman/agent/TransformContext.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/TransformContext.java
@@ -265,7 +265,7 @@ public class TransformContext
 
     public void recordFailedTransform(Throwable th)
     {
-        ruleScript.recordTransform(loader, triggerClassName, null, null, null, th);
+        ruleScript.recordFailedTransform(loader, triggerClassName, th);
 
         purgeRules();
     }

--- a/contrib/jboss-modules-system/tests/pom.xml
+++ b/contrib/jboss-modules-system/tests/pom.xml
@@ -277,10 +277,10 @@
 								<include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
 							</includes>
 							<argLine>${debug.options}
-								-javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport.btm
+								-javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestHelper.btm
                                 -Djboss.modules.system.pkgs=org.jboss.byteman
-								-Dmodulartest.module=testimport
-								-Dmodulartest.class=testimport.TestImport
+								-Dmodulartest.module=testhelper
+								-Dmodulartest.class=testhelper.TestHelper
 								-Dorg.jboss.byteman.compile.to.bytecode=true
 								-jar ${project.build.directory}/jboss-modules.jar
 								-mp ${project.build.directory}/modules-root

--- a/contrib/jboss-modules-system/tests/pom.xml
+++ b/contrib/jboss-modules-system/tests/pom.xml
@@ -182,7 +182,7 @@
 				<executions>
 					<!-- basic import testing -->
 					<execution>
-						<id>jbossmodules.TestImport</id>
+						<id>jbossmodules.TestImport_Local</id>
 						<phase>integration-test</phase>
 						<goals>
 							<goal>integration-test</goal>
@@ -192,13 +192,13 @@
 							<forkMode>always</forkMode>
 							<useSystemClassLoader>true</useSystemClassLoader>
 							<useManifestOnlyJar>false</useManifestOnlyJar>
-							<reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport</reportsDirectory>
+							<reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport_Local</reportsDirectory>
 							<includes>
 								<include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
 							</includes>
 							<argLine>
 							    ${debug.options}
-								-javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport.btm
+								-javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport_Local.btm
 								-Djboss.modules.system.pkgs=org.jboss.byteman
 								-Dmodulartest.module=testimport
 								-Dmodulartest.class=testimport.TestImport
@@ -209,7 +209,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>jbossmodules.TestImport-compiled</id>
+						<id>jbossmodules.TestImport_Local-compiled</id>
 						<phase>integration-test</phase>
 						<goals>
 							<goal>integration-test</goal>
@@ -219,12 +219,12 @@
 							<forkMode>always</forkMode>
 							<useSystemClassLoader>true</useSystemClassLoader>
 							<useManifestOnlyJar>false</useManifestOnlyJar>
-							<reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport-compiled</reportsDirectory>
+							<reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport_Local-compiled</reportsDirectory>
 							<includes>
 								<include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
 							</includes>
 							<argLine>${debug.options}
-								-javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport.btm
+								-javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport_Local.btm
                                 -Djboss.modules.system.pkgs=org.jboss.byteman
 								-Dmodulartest.module=testimport
 								-Dmodulartest.class=testimport.TestImport
@@ -234,6 +234,114 @@
 								-class </argLine>
 						</configuration>
 					</execution>
+                    <!-- global import testing -->
+                    <execution>
+                        <id>jbossmodules.TestImport_Global</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>always</forkMode>
+                            <useSystemClassLoader>true</useSystemClassLoader>
+                            <useManifestOnlyJar>false</useManifestOnlyJar>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport_Global</reportsDirectory>
+                            <includes>
+                                <include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
+                            </includes>
+                            <argLine>
+                                ${debug.options}
+                                -javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport_Global.btm
+                                -Djboss.modules.system.pkgs=org.jboss.byteman
+                                -Dmodulartest.module=testimport
+                                -Dmodulartest.class=testimport.TestImport
+                                -jar ${project.build.directory}/jboss-modules.jar
+                                -mp ${project.build.directory}/modules-root
+                                -class
+                            </argLine>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jbossmodules.TestImport_Global-compiled</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>always</forkMode>
+                            <useSystemClassLoader>true</useSystemClassLoader>
+                            <useManifestOnlyJar>false</useManifestOnlyJar>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport_Global-compiled</reportsDirectory>
+                            <includes>
+                                <include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
+                            </includes>
+                            <argLine>${debug.options}
+                                -javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport_Global.btm
+                                -Djboss.modules.system.pkgs=org.jboss.byteman
+                                -Dmodulartest.module=testimport
+                                -Dmodulartest.class=testimport.TestImport
+                                -Dorg.jboss.byteman.compile.to.bytecode=true
+                                -jar ${project.build.directory}/jboss-modules.jar
+                                -mp ${project.build.directory}/modules-root
+                                -class </argLine>
+                        </configuration>
+                    </execution>
+                    <!-- clearing global imports -->
+                    <execution>
+                        <id>jbossmodules.TestImport_Clearing</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>always</forkMode>
+                            <useSystemClassLoader>true</useSystemClassLoader>
+                            <useManifestOnlyJar>false</useManifestOnlyJar>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport_Clearing</reportsDirectory>
+                            <includes>
+                                <include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
+                            </includes>
+                            <argLine>
+                                ${debug.options}
+                                -javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport_Clearing.btm
+                                -Djboss.modules.system.pkgs=org.jboss.byteman
+                                -Dmodulartest.module=testimport
+                                -Dmodulartest.class=testimport.TestImportFailure
+                                -jar ${project.build.directory}/jboss-modules.jar
+                                -mp ${project.build.directory}/modules-root
+                                -class
+                            </argLine>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jbossmodules.TestImport_Clearing-compiled</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <forkMode>always</forkMode>
+                            <useSystemClassLoader>true</useSystemClassLoader>
+                            <useManifestOnlyJar>false</useManifestOnlyJar>
+                            <reportsDirectory>${project.build.directory}/failsafe-reports/jbossmodules.TestImport_Clearing-compiled</reportsDirectory>
+                            <includes>
+                                <include>byteman/tests/modules/jbossmodules/TestTrampoline.class</include>
+                            </includes>
+                            <argLine>${debug.options}
+                                -javaagent:${project.build.directory}/byteman.jar=sys:${project.build.directory}/byteman-jboss-modules-plugin.jar,modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,prop:org.jboss.byteman.verbose=true,script:${project.build.testOutputDirectory}/scripts/jbossmodules/TestImport_Clearing.btm
+                                -Djboss.modules.system.pkgs=org.jboss.byteman
+                                -Dmodulartest.module=testimport
+                                -Dmodulartest.class=testimport.TestImportFailure
+                                -Dorg.jboss.byteman.compile.to.bytecode=true
+                                -jar ${project.build.directory}/jboss-modules.jar
+                                -mp ${project.build.directory}/modules-root
+                                -class </argLine>
+                        </configuration>
+                    </execution>
 
 					<!-- helper testing -->
 					<execution>

--- a/contrib/jboss-modules-system/tests/src/main/java/testimport/TestImportFailure.java
+++ b/contrib/jboss-modules-system/tests/src/main/java/testimport/TestImportFailure.java
@@ -1,14 +1,15 @@
 package testimport;
 
-import byteman.tests.Test;
+import org.jboss.byteman.rule.exception.TypeException;
 
+import byteman.tests.Test;
 import runner.Runner;
 
-public class TestImport extends Test
+public class TestImportFailure extends Test
 {
-    public TestImport()
+    public TestImportFailure()
     {
-        super(TestImport.class.getCanonicalName());
+        super(TestImportFailure.class.getCanonicalName());
     }
 
     public void test()
@@ -33,7 +34,7 @@ public class TestImport extends Test
     @Override
     public String getExpected() {
         logExpected("calling TestImport.triggerMethod");
-        logExpected("TestImport $runnable");
+        // this will be missing, since the rule failed to compile: logExpected("TestImport $runnable");
         logExpected("Runnable.run");
         logExpected("called TestImport.triggerMethod");
 

--- a/contrib/jboss-modules-system/tests/src/main/java/testimport/TestRunnable.java
+++ b/contrib/jboss-modules-system/tests/src/main/java/testimport/TestRunnable.java
@@ -1,10 +1,12 @@
 package testimport;
 
+import byteman.tests.Test;
+
 public class TestRunnable implements Runnable
 {
-    private final TestImport ti;
+    private final Test ti;
 
-    public TestRunnable(TestImport ti)
+    public TestRunnable(Test ti)
     {
         this.ti = ti;
     }

--- a/contrib/jboss-modules-system/tests/src/test/resources/scripts/jbossmodules/TestImport_Clearing.btm
+++ b/contrib/jboss-modules-system/tests/src/test/resources/scripts/jbossmodules/TestImport_Clearing.btm
@@ -1,0 +1,36 @@
+##############################################################################
+# JBoss, Home of Professional Open Source
+# Copyright 2015, Red Hat and individual contributors
+# by the @authors tag. See the copyright.txt in the distribution for a
+# full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+# @authors James Livingston
+#
+# Test that we can clear a global import
+
+IMPORT testimport
+
+RULE check import of other module
+CLASS runner.Runner
+IMPORT
+METHOD run
+AT ENTRY
+BIND runnable : testimport.TestRunnable = $1;
+IF TRUE
+DO runnable.log("TestImport $runnable");
+ENDRULE

--- a/contrib/jboss-modules-system/tests/src/test/resources/scripts/jbossmodules/TestImport_Global.btm
+++ b/contrib/jboss-modules-system/tests/src/test/resources/scripts/jbossmodules/TestImport_Global.btm
@@ -1,0 +1,35 @@
+##############################################################################
+# JBoss, Home of Professional Open Source
+# Copyright 2015, Red Hat and individual contributors
+# by the @authors tag. See the copyright.txt in the distribution for a
+# full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+# @authors James Livingston
+#
+# Test that we can import a module not visible to the class, globally
+
+IMPORT testimport
+
+RULE check import of other module
+CLASS runner.Runner
+METHOD run
+AT ENTRY
+BIND runnable : testimport.TestRunnable = $1;
+IF TRUE
+DO runnable.log("TestImport $runnable");
+ENDRULE

--- a/contrib/jboss-modules-system/tests/src/test/resources/scripts/jbossmodules/TestImport_Local.btm
+++ b/contrib/jboss-modules-system/tests/src/test/resources/scripts/jbossmodules/TestImport_Local.btm
@@ -21,7 +21,7 @@
 #
 # @authors James Livingston
 #
-# Test that we can import a module not visible to the class
+# Test that we can import a module not visible to the class, local to a rule
 
 RULE check import of other module
 CLASS runner.Runner

--- a/contrib/jboss-modules-system/tests/verification.xml
+++ b/contrib/jboss-modules-system/tests/verification.xml
@@ -8,11 +8,27 @@
   -->
   <files>
     <file>
-      <location>target/failsafe-reports/jbossmodules.TestImport/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
+      <location>target/failsafe-reports/jbossmodules.TestImport_Local/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
       <exists/>
     </file>
     <file>
-      <location>target/failsafe-reports/jbossmodules.TestImport-compiled/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
+      <location>target/failsafe-reports/jbossmodules.TestImport_Local-compiled/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
+      <exists/>
+    </file>
+    <file>
+      <location>target/failsafe-reports/jbossmodules.TestImport_Global/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
+      <exists/>
+    </file>
+    <file>
+      <location>target/failsafe-reports/jbossmodules.TestImport_Global-compiled/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
+      <exists/>
+    </file>
+    <file>
+      <location>target/failsafe-reports/jbossmodules.TestImport_Clearing/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
+      <exists/>
+    </file>
+    <file>
+      <location>target/failsafe-reports/jbossmodules.TestImport_Clearing-compiled/byteman.tests.modules.jbossmodules.TestTrampoline.txt</location>
       <exists/>
     </file>
     <file>


### PR DESCRIPTION
This add the functionality for BYTEMAN-307, with some more tests.

I have a test which deliberately fails rule compilation, which I test for by the logging the rule adds not being present - is there a better way to do that?

The other commit fixes a copy and past error in the test code, where the compiled version of TestHelper ran the TestImport code with the TestImport rule (so it didn't fail).