### PR TITLE
bminstall script for mac

### DIFF
--- a/bin/bminstall.sh
+++ b/bin/bminstall.sh
@@ -78,29 +78,13 @@ if [ $JAVA_VERSION -le 8 ]; then
      echo "please set JAVA_HOME"
      exit
   fi
-# on Linux we need to add the tools jar to the path
-# this is not currently needed on a Mac
-  OS=`uname`
-  if [ ${OS} != "Darwin" ]; then
-    if [ -r ${JAVA_HOME}/lib/tools.jar ]; then
-      TOOLS_JAR=${JAVA_HOME}/lib/tools.jar
-      CP=${BYTEMAN_INSTALL_JAR}:${TOOLS_JAR}
-    else
-      echo "Cannot locate tools jar"
-      CP=${BYTEMAN_INSTALL_JAR}
-    fi
+  # on Linux and Mac we need to add the tools jar to the path
+  if [ -r ${JAVA_HOME}/lib/tools.jar ]; then
+    TOOLS_JAR=${JAVA_HOME}/lib/tools.jar
+    CP=${BYTEMAN_INSTALL_JAR}:${TOOLS_JAR}
   else
-    if [ $JAVA_VERSION -gt 6 ]; then
-      if [ -r ${JAVA_HOME}/Classes/classes.jar ]; then
-        TOOLS_JAR=${JAVA_HOME}/Classes/classes.jar
-        CP=${BYTEMAN_INSTALL_JAR}:${TOOLS_JAR}
-      else
-        echo "Cannot locate tools jar"
-        CP=${BYTEMAN_INSTALL_JAR}
-      fi
-    else
-      CP=${BYTEMAN_INSTALL_JAR}                          
-    fi
+    echo "Cannot locate tools jar"
+    CP=${BYTEMAN_INSTALL_JAR}
   fi
 else
   CP=${BYTEMAN_INSTALL_JAR}


### PR DESCRIPTION
Hello, an amendment has been made on the bminstall.sh script which was not anymore compatible with current OS. By testing with Jdks from 1.6 to 1.8 I could not understand why a switch was introduced in an attempt to load Classes.jar (maybe that was the case in really old jdk releases prior to 1.6).

My reference installation structure for the test:

ls /Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/
bin    bundle lib    man

ls /Library/Java/JavaVirtualMachines/jdk1.7.0_67.jdk/Contents/Home/
COPYRIGHT                          THIRDPARTYLICENSEREADME-JAVAFX.txt db                                 lib                                src.zip
LICENSE                            THIRDPARTYLICENSEREADME.txt        include                            man
README.html                        bin                                jre                                release

ls /Library/Java/JavaVirtualMachines/jdk1.8.0_60.jdk/Contents/Home/
COPYRIGHT                          THIRDPARTYLICENSEREADME-JAVAFX.txt db                                 jre                                release
LICENSE                            THIRDPARTYLICENSEREADME.txt        include                            lib                                src.zip
README.html                        bin                                javafx-src.zip                     man
