### PR TITLE
Fix StringIndexOutOfBoundsException

### DIFF
--- a/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnitConfigState.java
+++ b/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnitConfigState.java
@@ -990,7 +990,7 @@ public class BMUnitConfigState
             }
         }
         int l = dir.length();
-        if (l > 0 && dir.charAt(l) != '/') {
+        if (l > 0 && dir.charAt(l - 1) != '/') {
             dir = dir + "/";
         }
         return dir;


### PR DESCRIPTION
Fix in loading the directory where if the property was set a java.lang.StringIndexOutOfBoundsException would always be thrown because the call to charAt was called with the length of the String instead of length - 1.