### PR TITLE
Updating byteman sample ThreadHistoryMonitorHelper to store all events

### DIFF
--- a/sample/scripts/ThreadMonitorHistory.btm
+++ b/sample/scripts/ThreadMonitorHistory.btm
@@ -56,7 +56,7 @@
 #
 
 RULE ThreadMonitor trace create
-CLASS ^java.lang.Thread
+CLASS java.lang.Thread
 METHOD <init>
 HELPER org.jboss.byteman.sample.helper.ThreadHistoryMonitorHelper
 AT EXIT
@@ -140,4 +140,14 @@ HELPER org.jboss.byteman.sample.helper.ThreadHistoryMonitorHelper
 AT EXIT
 IF TRUE
 do writeAllEventsToFile("/tmp/thread-events.txt")
+ENDRULE
+
+# A rule to trigger a flush of the events on System.exit
+RULE write ThreadHistoryMonitorHelper to a file manu
+CLASS java.lang.System
+METHOD exit
+HELPER org.jboss.byteman.sample.helper.ThreadHistoryMonitorHelper
+AT ENTRY
+IF TRUE
+do writeAllEventsToFile("/tmp/thread-system-exit.txt")
 ENDRULE

--- a/sample/src/org/jboss/byteman/sample/helper/ThreadHistoryMonitorHelper.java
+++ b/sample/src/org/jboss/byteman/sample/helper/ThreadHistoryMonitorHelper.java
@@ -26,7 +26,6 @@ package org.jboss.byteman.sample.helper;
 
 import org.jboss.byteman.rule.Rule;
 import org.jboss.byteman.rule.helper.Helper;
-
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.io.FileWriter;
@@ -36,20 +35,23 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Formatter;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * <p>
  * Helper class used by ThreadHistoryMonitorHelper script to trace thread operations. This
  * is essentially an extension of the ThreadMonitorHelper which uses maps to store the thread
  * history rather than writing it out.
- *
+ * <p>
  * The helper also implements ThreadHistoryMonitorHelperMXBean to allow this class to be
  * registered as an mbean @see #registerHelperMBean(String).
  * 
@@ -57,10 +59,14 @@ import java.util.concurrent.TimeUnit;
 public class ThreadHistoryMonitorHelper extends Helper
     implements ThreadHistoryMonitorHelperMXBean
 {
-    private static ConcurrentHashMap<String, ThreadMonitorEvent> createMap = new ConcurrentHashMap<String, ThreadMonitorEvent>();
-    private static ConcurrentHashMap<String, ThreadMonitorEvent> startMap = new ConcurrentHashMap<String, ThreadMonitorEvent>();
-    private static ConcurrentHashMap<String, ThreadMonitorEvent> exitMap = new ConcurrentHashMap<String, ThreadMonitorEvent>();
-    private static ConcurrentHashMap<String, ThreadMonitorEvent> runMap = new ConcurrentHashMap<String, ThreadMonitorEvent>();
+    private static Map<ThreadMonitored, ThreadMonitored> monitoredThreads =
+            new ConcurrentHashMap<ThreadMonitored, ThreadMonitored>();
+    private static Queue<ThreadMonitorEvent> createList      = new ConcurrentLinkedQueue<ThreadMonitorEvent>();
+    private static Queue<ThreadMonitorEvent> startList       = new ConcurrentLinkedQueue<ThreadMonitorEvent>();
+    private static Queue<ThreadMonitorEvent> exitList        = new ConcurrentLinkedQueue<ThreadMonitorEvent>();
+    private static Queue<ThreadMonitorEvent> runList         = new ConcurrentLinkedQueue<ThreadMonitorEvent>();
+    private static Queue<ThreadMonitorEvent> interruptedList = new ConcurrentLinkedQueue<ThreadMonitorEvent>();
+
     /** The first instance of ThreadHistoryMonitorHelper that will be used as the mbean
      * by {@link #registerHelperMBean(String)}.
      */
@@ -75,11 +81,11 @@ public class ThreadHistoryMonitorHelper extends Helper
     public static void activated() {
         DEBUG = Boolean.getBoolean("org.jboss.byteman.sample.helper.debug");
         if(DEBUG)
-            Helper.out("ThreadHistoryMonitorHelper.activated, ");
+            System.err.println("ThreadHistoryMonitorHelper.activated, ");
     }
     public static void installed(Rule rule) {
         if(DEBUG)
-            Helper.out("ThreadHistoryMonitorHelper.installed, "+rule);
+            System.err.println("ThreadHistoryMonitorHelper.installed, "+rule);
     }
     protected ThreadHistoryMonitorHelper(Rule rule) {
         super(rule);
@@ -91,7 +97,7 @@ public class ThreadHistoryMonitorHelper extends Helper
      * @param name - the object name string to register the INSTANCE under
      */
     public void registerHelperMBean(String name) {
-        synchronized (createMap) {
+        synchronized (createList) {
             MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             try {
                 ObjectName oname = new ObjectName(name);
@@ -103,53 +109,125 @@ public class ThreadHistoryMonitorHelper extends Helper
         }
     }
 
-    @Override
+    /**
+     * trace creation of the supplied thread to System.out
+     *
+     * this should only be triggered from the {@link Thread} constructor
+     *
+     * @param thread the newly created thread
+     * @param depth unused
+     */
+    public void traceCreate(Thread thread, int depth)
+    {
+        ThreadMonitored monitoredThread = getMonitoredThread(thread);
+        ThreadMonitored createdByMonitoredThread = getMonitoredThread(Thread.currentThread());
+        monitoredThread.setCreatedBy(createdByMonitoredThread);
+
+        ThreadMonitorEvent event = newThreadEvent(monitoredThread, thread, ThreadMonitorEventType.CREATE);
+        createList.add(event);
+
+    }
+
+    /**
+     * trace start of the supplied thread to System.out
+     *
+     * this should only be triggered from the call to java.lang.Thread.start"
+     *
+     * @param thread the newly starting thread
+     */
+    public void traceStart(Thread thread)
+    {
+        ThreadMonitored monitoredThread = getMonitoredThread(thread);
+        ThreadMonitorEvent event = newThreadEvent(monitoredThread, thread, ThreadMonitorEventType.START);
+        startList.add(event);
+    }
+
+    /**
+     * trace exit of the supplied thread to System.out
+     *
+     * this should only be triggered from the call to {@link Thread} exit method
+     *
+     * @param thread the exiting thread
+     */
+    public void traceExit(Thread thread)
+    {
+        ThreadMonitored monitoredThread = getMonitoredThread(thread);
+        ThreadMonitorEvent event = newThreadEvent(monitoredThread, thread, ThreadMonitorEventType.EXIT);
+        exitList.add(event);
+    }
+    
+    /**
+     * trace interrupted of the supplied thread to System.out
+     *
+     * this should only be triggered from the call to {@link Thread#interrupt()}
+     *
+     * @param thread  the interrupting thread
+     */
+    public void traceInterrupt(Thread thread)
+    {
+        ThreadMonitored monitoredThread = getMonitoredThread(thread);
+        ThreadMonitorEvent event = newThreadEvent(monitoredThread, thread, ThreadMonitorEventType.INTERRUPT);
+        interruptedList.add(event);
+    }
+
+    /**
+     * trace run of the supplied Runnable to System.out
+     *
+     * this should only be triggered from a call to an implementation of {@link Runnable#run()}
+     *
+     * @param runnable the runnable being run
+     */
+    public void traceRun(Runnable runnable)
+    {
+        Thread thread = Thread.currentThread();
+        ThreadMonitored monitoredThread = getMonitoredThread(thread);
+        monitoredThread.setRunnableClass(runnable.getClass());
+        ThreadMonitorEvent event = newThreadEvent(monitoredThread, thread, ThreadMonitorEventType.RUN);
+        runList.add(event);
+    }
+
     public ThreadMonitorEvent[] getCreateEvents() {
-        ThreadMonitorEvent[] events = new ThreadMonitorEvent[createMap.size()];
-        return createMap.values().toArray(events);
+        ThreadMonitorEvent[] events = new ThreadMonitorEvent[createList.size()];
+        return createList.toArray(events);
     }
 
-    @Override
     public ThreadMonitorEvent[] getStartEvents() {
-        ThreadMonitorEvent[] events = new ThreadMonitorEvent[startMap.size()];
-        return startMap.values().toArray(events);
+        ThreadMonitorEvent[] events = new ThreadMonitorEvent[startList.size()];
+        return startList.toArray(events);
     }
 
-    @Override
     public ThreadMonitorEvent[] getExitEvents() {
-        ThreadMonitorEvent[] events = new ThreadMonitorEvent[exitMap.size()];
-        return exitMap.values().toArray(events);
+        ThreadMonitorEvent[] events = new ThreadMonitorEvent[exitList.size()];
+        return exitList.toArray(events);
     }
 
-    @Override
     public ThreadMonitorEvent[] getRunEvents() {
-        ThreadMonitorEvent[] events = new ThreadMonitorEvent[runMap.size()];
-        return runMap.values().toArray(events);
+        ThreadMonitorEvent[] events = new ThreadMonitorEvent[runList.size()];
+        return runList.toArray(events);
     }
 
-    @Override
     public String getEventReport() throws IOException {
         StringWriter sw = new StringWriter();
         Formatter format = new Formatter(sw);
-        writeEvents(format, "Thread.create", createMap.values());
-        writeEvents(format, "Thread.start", startMap.values());
-        writeEvents(format, "Thread.exit", exitMap.values());
-        writeEvents(format, "Runable.run", runMap.values());
+        writeFullEvents(format, "Thread.create", createList);
+        writeFullEvents(format, "Thread.start", startList);
+        writeFullEvents(format, "Thread.exit", exitList);
+        writeFullEvents(format, "Runable.run", runList);
         sw.close();
         return sw.toString();
     }
-    @Override
+
     public void writeEventsToFile(String type, String path) throws IOException {
         FileWriter fw = new FileWriter(path);
         Formatter format = new Formatter(fw);
         if(type == null || type.length() == 0 || type.equalsIgnoreCase("create"))
-            writeEvents(format, "Thread.create Events", createMap.values());
+            writeFullEvents(format, "Thread.create Events", createList);
         if(type == null || type.length() == 0 || type.equalsIgnoreCase("start"))
-            writeEvents(format, "Thread.start Events", startMap.values());
+            writeFullEvents(format, "Thread.start Events", startList);
         if(type == null || type.length() == 0 || type.equalsIgnoreCase("exit"))
-            writeEvents(format, "Thread.exit Events", exitMap.values());
+            writeFullEvents(format, "Thread.exit Events", exitList);
         if(type == null || type.length() == 0 || type.equalsIgnoreCase("run"))
-            writeEvents(format, "Runable.run Events", runMap.values());
+            writeFullEvents(format, "Runable.run Events", runList);
         fw.close();
     }
 
@@ -160,7 +238,7 @@ public class ThreadHistoryMonitorHelper extends Helper
      * @throws IOException if an io error occurs
      */
     public void writeAllEventsToFile(String path) throws IOException {
-        Helper.out("writeAllEventsToFile: "+path);
+        System.err.println("writeAllEventsToFile: "+path);
         writeAllEventsToFile(path, 0);
     }
 
@@ -218,27 +296,46 @@ public class ThreadHistoryMonitorHelper extends Helper
     private void doWriteAllEvents(String path) throws IOException {
         FileWriter fw = new FileWriter(path);
         Formatter format = new Formatter(fw);
-        writeEvents(format, "Thread.create", createMap.values());
-        writeEvents(format, "Thread.start", startMap.values());
-        writeEvents(format, "Thread.exit", exitMap.values());
-        writeEvents(format, "Runable.run", runMap.values());
+        writeFullEvents(format, "Thread.create", createList);
+        writeFullEvents(format, "Thread.start", startList);
+        writeFullEvents(format, "Thread.exit", exitList);
+        writeFullEvents(format, "Runable.run", runList);
+        
+        // thread which were started but not exited yet
+        Map<ThreadMonitored, ThreadMonitorEvent> runningThreads = getThreadEventMap(startList);
+        for(ThreadMonitorEvent exitEvent: exitList) {
+            runningThreads.remove(exitEvent.getMonitoredThread());
+        }
+        writeThreadNames(format, "Thread.start but not exit", runningThreads.values());
+
         fw.close();
-        Helper.out("Wrote events to: "+path);
+        System.err.println("Wrote events to: " + path);
     }
-    private void writeEvents(Formatter fw, String title, Collection<ThreadMonitorEvent> events) {
+
+    private void writeFullEvents(Formatter fw, String title, Collection<ThreadMonitorEvent> events) {
         int count = 0;
-        TreeSet<String> threadNames = new TreeSet<String>();
+        List<String> threadNames = new ArrayList<String>();
         fw.format("+++ Begin %s Events, count=%d +++\n", title, events.size());
         for(ThreadMonitorEvent event : events) {
-            if(event.getRunnableClass() != null) {
-                fw.format("#%d, %s(runnable=%s)\n%s\n", count++, event.getThreadName(), event.getRunnableClass(), event.getFullStack());
+            ThreadMonitored thread = event.getMonitoredThread();
+            if(thread.getRunnableClass() != null) {
+                fw.format("#%d [%s], %s:%s(runnable=%s, by=%s)\n%s\n", count++, title, thread.getThreadName(), thread.getThreadId(),
+                        thread.getRunnableClass(), thread.getCreatedBy(), event.getFullStack());
             } else {
-                fw.format("#%d, %s\n%s\n", count++, event.getThreadName(), event.getFullStack());
+                fw.format("#%d [%s], %s:%s(by=%s)\n%s\n", count++, title, thread.getThreadName(), thread.getThreadId(), thread.getCreatedBy(), event.getFullStack());
             }
-            threadNames.add(event.getThreadName());
+            threadNames.add(thread.toString());
         }
         fw.format("+++ End %s Events +++\n", title);
-        fw.format("+++ Begin %s Thread Names +++\n", title);
+        writeThreadNames(fw, title, events);;
+    }
+    
+    private void writeThreadNames(Formatter fw, String title, Collection<ThreadMonitorEvent> events) {
+        List<String> threadNames = new ArrayList<String>();
+        for(ThreadMonitorEvent event : events) {
+            threadNames.add(event.getMonitoredThread().toString());
+        }
+        fw.format("+++ Begin %s Thread Names (count=%s) +++\n", title, threadNames.size());
         for(String name : threadNames) {
             fw.format("%s\n", name);
         }
@@ -246,69 +343,13 @@ public class ThreadHistoryMonitorHelper extends Helper
     }
 
     /**
-     * trace creation of the supplied thread to System.out
-     *
-     * this should only be triggered from the constructor for class java.lang.Thread"
-     *
-     * @param thread the newly created thread
-     * @param depth unused
-     */
-    public void traceCreate(Thread thread, int depth)
-    {
-        ThreadMonitorEvent event = newThreadEvent(thread, "create");
-        createMap.put(event.getThreadName(), event);
-
-    }
-
-    /**
-     * trace start of the supplied thread to System.out
-     *
-     * this should only be triggered from the call to java.lang.Thread.start"
-     *
-     * @param thread the newly starting thread
-     */
-    public void traceStart(Thread thread)
-    {
-        ThreadMonitorEvent event = newThreadEvent(thread, "start");
-        startMap.put(event.getThreadName(), event);
-    }
-
-    /**
-     * trace exit of the supplied thread to System.out
-     *
-     * this should only be triggered from the call to java.lang.Thread.exit"
-     *
-     * @param thread the exiting thread
-     */
-    public void traceExit(Thread thread)
-    {
-        ThreadMonitorEvent event = newThreadEvent(thread, "exit");
-        exitMap.put(event.getThreadName(), event);
-    }
-
-    /**
-     * trace run of the supplied Runnable to System.out
-     *
-     * this should only be triggered from a call to an implementation of java.lang.Runnable.run"
-     *
-     * @param runnable the runnable being run
-     */
-    public void traceRun(Runnable runnable)
-    {
-        Thread thread = Thread.currentThread();
-        ThreadMonitorEvent event = newThreadEvent(thread, "run");
-        event.setRunnableClass(runnable.getClass().toString());
-        runMap.put(event.getThreadName(), event);
-    }
-
-    /**
      * Common ThreadMonitorEvent creation method.
      *
      * @param thread - the thread associated with the event
-     * @param type - the type of the event.
+     * @param eventType - the type of the event.
      * @return the ThreadMonitorEvent instance for the event.
      */
-    private ThreadMonitorEvent newThreadEvent(Thread thread, String type) {
+    public ThreadMonitorEvent newThreadEvent(ThreadMonitored threadMonitored, Thread thread, ThreadMonitorEventType eventType) {
         StringBuffer line = new StringBuffer();
         StringBuilder buffer = new StringBuilder();
         StackTraceElement[] stack = getStack();
@@ -317,7 +358,7 @@ public class ThreadHistoryMonitorHelper extends Helper
         int t = super.triggerIndex(stack);
 
         line.append("*** Thread ");
-        line.append(type);
+        line.append(eventType);
         line.append(" ");
         line.append(thread.getName());
         line.append(" ");
@@ -334,10 +375,36 @@ public class ThreadHistoryMonitorHelper extends Helper
             line.setLength(0);
         }
         //
-        String name = thread.getName();
         String fullStack = buffer.toString();
-        ThreadMonitorEvent event = new ThreadMonitorEvent(type, name, stackInfo, fullStack);
-        return event;
+        ThreadMonitorEvent threadEvent = new ThreadMonitorEvent(threadMonitored, eventType, stackInfo, fullStack);
+        return threadEvent;
     }
 
+    /**
+     * Returning monitored thread belonging to the provided thread object.
+     * If such monitored thread does not exist (is not known to {@link ThreadHistoryMonitorHelper})
+     * then brand new {@link ThreadMonitored} object is created and is added to the list
+     * checked by the helper class.
+     *
+     * @param thread  thread that belonging  ThreadMonitorThread is search for
+     * @return  ThreadMonitorThread which belongs to provided thread or null in no such known
+     */
+    private ThreadMonitored getMonitoredThread(Thread thread) {
+        ThreadMonitored mt = ThreadMonitored.newMonitoredThread(thread);
+        if(monitoredThreads.containsKey(mt)) {
+            return monitoredThreads.get(mt);
+        } else {
+            monitoredThreads.put(mt, mt);
+            return mt;
+        }
+    }
+
+
+    private Map<ThreadMonitored, ThreadMonitorEvent> getThreadEventMap(Iterable<ThreadMonitorEvent> events) {
+        Map<ThreadMonitored, ThreadMonitorEvent> threadEventMap = new HashMap<ThreadMonitored, ThreadMonitorEvent>();
+        for(ThreadMonitorEvent event: events) {
+            threadEventMap.put(event.getMonitoredThread(), event);
+        }
+        return threadEventMap;
+    }
 }

--- a/sample/src/org/jboss/byteman/sample/helper/ThreadMonitorEvent.java
+++ b/sample/src/org/jboss/byteman/sample/helper/ThreadMonitorEvent.java
@@ -22,7 +22,6 @@
 */
 package org.jboss.byteman.sample.helper;
 
-import java.beans.ConstructorProperties;
 import java.io.Serializable;
 import java.util.Collection;
 
@@ -33,34 +32,25 @@ import java.util.Collection;
 public class ThreadMonitorEvent implements Serializable {
     private static final long serialVersionUID = 1;
 
-    private String event;
-    private String threadName;
-    private String runnableClass;
+    private ThreadMonitored monitoredThread;
+    private ThreadMonitorEventType eventType;;
     private String[] stack;
     private String fullStack;
-
-    @ConstructorProperties({"event", "threadName", "stack"})
-    public ThreadMonitorEvent(String event, String threadName, Collection<String> stack, String fullStack) {
-        this.event = event;
-        this.threadName = threadName;
+    
+    public ThreadMonitorEvent(ThreadMonitored monitoredThread, ThreadMonitorEventType eventType, Collection<String> stack, String fullStack) {
+        this.eventType = eventType;
+        this.monitoredThread = monitoredThread;
         this.stack = new String[stack.size()];
         stack.toArray(this.stack);
         this.fullStack = fullStack;
     }
 
-    public String getEvent() {
-        return event;
+    public ThreadMonitorEventType getEventType() {
+        return eventType;
     }
-
-    public String getThreadName() {
-        return threadName;
-    }
-
-    public String getRunnableClass() {
-        return runnableClass;
-    }
-    public void setRunnableClass(String runnableClass) {
-        this.runnableClass = runnableClass;
+   
+    public ThreadMonitored getMonitoredThread() {
+        return monitoredThread;
     }
 
     public String[] getStack() {
@@ -69,5 +59,5 @@ public class ThreadMonitorEvent implements Serializable {
 
     public String getFullStack() {
         return fullStack;
-    }
+     }
 }

--- a/sample/src/org/jboss/byteman/sample/helper/ThreadMonitorEventType.java
+++ b/sample/src/org/jboss/byteman/sample/helper/ThreadMonitorEventType.java
@@ -1,0 +1,5 @@
+package org.jboss.byteman.sample.helper;
+
+public enum ThreadMonitorEventType {
+    CREATE, START, EXIT, INTERRUPT, RUN
+}

--- a/sample/src/org/jboss/byteman/sample/helper/ThreadMonitored.java
+++ b/sample/src/org/jboss/byteman/sample/helper/ThreadMonitored.java
@@ -1,0 +1,125 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2016 Red Hat and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*
+*/
+package org.jboss.byteman.sample.helper;
+
+import java.io.Serializable;
+
+/**
+ * This is a DTO object which contains an identity of a real {@link Thread} object.
+ * This one is used for monitoring of thread creation and termination.
+ * Additional stack trace data are gathered by {@link ThreadMonitorEvent} objects
+ * and processed in {@link ThreadHistoryMonitorHelper}. 
+ */
+public class ThreadMonitored implements Serializable {
+    private static final long serialVersionUID = 1;
+
+    private String threadName;
+    private long threadId;
+    private int threadHashCode;
+    private String runnableClass;
+    private ThreadMonitored createdBy;
+
+    /**
+     * Creating new instance of {@link ThreadMonitored}. Data is drained
+     * from the supplied {@link Thread} instance.
+     */
+    public static ThreadMonitored newMonitoredThread(final Thread thread) {
+        return new ThreadMonitored(thread.getName(), thread.getId(), thread.hashCode());
+    }
+
+    private ThreadMonitored(String threadName, long threadId, int threadHashCode) {
+        this.threadId = threadId;
+        this.threadName = threadName;
+        this.threadHashCode = threadHashCode;
+    }
+
+    public String getThreadName() {
+        return threadName;
+    }
+    
+    public long getThreadId() {
+        return threadId;
+    }
+
+    public String getRunnableClass() {
+        return runnableClass;
+    }
+
+    public void setRunnableClass(Class<?> runnableClass) {
+        this.runnableClass = runnableClass.toString();
+    }
+
+    public void setCreatedBy(ThreadMonitored createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public ThreadMonitored getCreatedBy() {
+        return createdBy;
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer eventId = new StringBuffer()
+            .append(getThreadName())
+            .append(":")
+            .append(getThreadId());
+        if(getRunnableClass() != null) {
+            eventId
+                .append("(")
+                .append(getRunnableClass())
+                .append(")");
+        }
+        return eventId.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + threadHashCode;
+        result = prime * result + (int) (threadId ^ (threadId >>> 32));
+        result = prime * result + ((threadName == null) ? 0 : threadName.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof ThreadMonitored))
+            return false;
+        ThreadMonitored other = (ThreadMonitored) obj;
+        if (threadHashCode != other.threadHashCode)
+            return false;
+        if (threadId != other.threadId)
+            return false;
+        if (threadName == null) {
+            if (other.threadName != null)
+                return false;
+        } else if (!threadName.equals(other.threadName))
+            return false;
+        return true;
+    }
+}


### PR DESCRIPTION
During investigation of some leaks I used  benefits of Byteman to track thread activity. I used code from `sample`s but I found that it does not store all the thread activity. Monitor all activity would be beneficial. I changed the code and I propose my changes in this PR.

This contains

Updating and refactoring ThreadHistoryMonitorHelper to get stored all events which happens during program execution.

Till now Map was used with key based on thread name. Thread name can be easily
the same for several threads. History was quite sparse.

Thread event history should store all events and it's up to developer to query the results.