### PR TITLE
Added support for older jboss-modules (1.2.0) and new "-m" option for byteman -install

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
     </parent>
     <properties>
         <debug.args>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005</debug.args>

--- a/bin/bminstall.bat
+++ b/bin/bminstall.bat
@@ -26,14 +26,15 @@
 @rem a JVM which was started without the agent. This provides an
 @rem alternative to using the -javaagent java command line flag
 @rem
-@rem usage: bminstall [-p port] [-h host] [-b] [-s] [-Dname[=value]]* pid
+@rem usage: bminstall [-p port] [-h host] [-b] [-s] [-m] [-Dname[=value]]* pid
 @rem   pid is the process id of the target JVM
 @rem   -h host selects the host name or address the agent listener binds to
 @rem   -p port selects the port the agent listener binds to
 @rem   -b adds the byteman jar to the bootstrap classpath
 @rem   -s sets an access-all-areas security policy for the Byteman agent code
+@rem   -m activates the byteman JBoss modules plugin
 @rem   -Dname=value can be used to set system properties whose name starts with "org.jboss.byteman."
-@rem   expects to find a byteman agent jar in BYTEMAN_HOME
+@rem   expects to find a byteman agent jar and byteman JBoss modules plugin jar (if -m is indicated) in BYTEMAN_HOME
 @rem
 @rem -----------------------------------------------------------------------------------
 if "%OS%" == "Windows_NT" setlocal
@@ -84,12 +85,13 @@ if "%OS%" == "Windows_NT" endlocal
 exit /b
 
 :showUsage
-echo usage: bminstall [-p port] [-h host] [-b] [-s] [-Dname[=value]]* pid
+echo usage: bminstall [-p port] [-h host] [-b] [-s] [-m] [-Dname[=value]]* pid
 echo   pid is the process id of the target JVM
 echo   -h host selects the host name or address the agent listener binds to
 echo   -p port selects the port the agent listener binds to
 echo   -b adds the byteman jar to the bootstrap classpath
 echo   -s sets an access-all-areas security policy for the Byteman agent code
+echo   -m activates the byteman JBoss modules plugin
 echo   -Dname=value can be used to set system properties whose name starts with "org.jboss.byteman."
-echo   expects to find a byteman agent jar in BYTEMAN_HOME
+echo   expects to find a byteman agent jar and byteman JBoss modules plugin jar (if -m is indicated) in BYTEMAN_HOME
 goto exitBatch

--- a/bin/bminstall.sh
+++ b/bin/bminstall.sh
@@ -25,14 +25,15 @@
 # a JVM which was started without the agent. This provides an
 # alternative to using the -javaagent java command line flag
 #
-# usage: bminstall [-p port] [-h host] [-b] [-s] [-Dname[=value]]* pid
+# usage: bminstall [-p port] [-h host] [-b] [-s] [-m] [-Dname[=value]]* pid
 #   pid is the process id of the target JVM
 #   -h host selects the host name or address the agent listener binds to
 #   -p port selects the port the agent listener binds to
 #   -b adds the byteman jar to the bootstrap classpath
 #   -s sets an access-all-areas security policy for the Byteman agent code
+#   -m activates the byteman JBoss modules plugin
 #   -Dname=value can be used to set system properties whose name starts with "org.jboss.byteman."
-#   expects to find a byteman agent jar in BYTEMAN_HOME
+#   expects to find a byteman agent jar and byteman JBoss modules plugin jar (if -m is indicated) in BYTEMAN_HOME
 #
 
 # helper function to obtain java version

--- a/bin/bmsetenv.bat
+++ b/bin/bmsetenv.bat
@@ -41,3 +41,8 @@ exit /b 1
 
 :okJar
 set "BYTEMAN_JAR=%BYTEMAN_HOME%\lib\byteman.jar"
+if exist "%BYTEMAN_HOME%\contrib\jboss-modules-system\byteman-jboss-modules-plugin.jar" goto okPluginJar
+echo Cannot locate byteman JBoss modules plugin jar
+
+:okPluginJar
+set "BYTEMAN_MODULES_PLUGIN_JAR=%BYTEMAN_HOME%\contrib\jboss-modules-system\byteman-jboss-modules-plugin.jar"

--- a/contrib/bmunit/pom.xml
+++ b/contrib/bmunit/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <build>

--- a/contrib/dtest/pom.xml
+++ b/contrib/dtest/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/contrib/jboss-modules-system/plugin/pom.xml
+++ b/contrib/jboss-modules-system/plugin/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-jboss-modules</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/contrib/jboss-modules-system/plugin/src/main/java/org/jboss/byteman/modules/jbossmodules/JBossModulesSystem.java
+++ b/contrib/jboss-modules-system/plugin/src/main/java/org/jboss/byteman/modules/jbossmodules/JBossModulesSystem.java
@@ -89,7 +89,17 @@ public class JBossModulesSystem implements ModuleSystem<ClassbyteClassLoader>
                 }
             }
         };
-        ruleModuleLoader = new ModuleLoader(finders);
+        ruleModuleLoader = new ModuleLoaderWrapper(finders);
+    }
+    
+    /**
+     * Utility class to allow instantiating {@link ModuleLoader} with jboss-modules <= 1.2.0 (protected constructors)
+     */
+    public class ModuleLoaderWrapper extends ModuleLoader
+    {
+        public ModuleLoaderWrapper(ModuleFinder[] finders) {
+            super(finders);
+        }
     }
 
     public ClassbyteClassLoader createLoader(ClassLoader triggerClassLoader, String[] imports)

--- a/contrib/jboss-modules-system/pom.xml
+++ b/contrib/jboss-modules-system/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/contrib/jboss-modules-system/tests/pom.xml
+++ b/contrib/jboss-modules-system/tests/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.jboss.byteman</groupId>
 		<artifactId>byteman-jboss-modules</artifactId>
-		<version>3.0.8</version>
+		<version>3.0.9-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/contrib/rulecheck-maven-plugin/example/pom.xml
+++ b/contrib/rulecheck-maven-plugin/example/pom.xml
@@ -18,7 +18,7 @@
       <plugin>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-rulecheck-maven-plugin</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
         <executions>
           <execution>
             <id>rulecheck-test</id>

--- a/contrib/rulecheck-maven-plugin/pom.xml
+++ b/contrib/rulecheck-maven-plugin/pom.xml
@@ -32,7 +32,7 @@
 	<parent>
 		<groupId>org.jboss.byteman</groupId>
 		<artifactId>byteman-root</artifactId>
-		<version>3.0.8</version>
+		<version>3.0.9-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
-			<version>3.0.8</version>
+			<version>3.0.9-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/docs/asciidoc/pom.xml
+++ b/docs/asciidoc/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.jboss.byteman</groupId>
     <artifactId>byteman-docs</artifactId>
-    <version>3.0.8</version>
+    <version>3.0.9-SNAPSHOT</version>
   </parent>
     
   <artifactId>byteman-asciidoc</artifactId>
-  <version>3.0.8</version>
+  <version>3.0.9-SNAPSHOT</version>
   <name>Byteman AsciiDoc Documentation</name>
 
   <properties>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.jboss.byteman</groupId>
     <artifactId>byteman-root</artifactId>
-    <version>3.0.8</version>
+    <version>3.0.9-SNAPSHOT</version>
   </parent>
     
   <artifactId>byteman-docs</artifactId>
-  <version>3.0.8</version>
+  <version>3.0.9-SNAPSHOT</version>
   <name>Byteman Documentation</name>
   <packaging>pom</packaging>
 

--- a/download/pom.xml
+++ b/download/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
     </parent>
     <description>
         The Byteman download includes the byteman agent, submit and install jars. the contributed

--- a/install/pom.xml
+++ b/install/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
     </parent>
 
     <profiles>

--- a/install/src/main/java/org/jboss/byteman/agent/install/Install.java
+++ b/install/src/main/java/org/jboss/byteman/agent/install/Install.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.jar.JarFile;
 
+import javax.swing.JButton;
+
 /**
  * A program which uses the sun.com.tools.attach.VirtualMachine class to install the Byteman agent into a
  * running JVM. This provides an alternative to using the -javaagent option to install the agent.
@@ -43,7 +45,7 @@ public class Install
      * main routine for use from command line
      *
      *
-     * Install [-h host] [-p port] [-b] [-s] [-Dorg.jboss.Byteman.xxx]* pid
+     * Install [-h host] [-p port] [-b] [-s] [-m] [-Dorg.jboss.Byteman.xxx]* pid
      *
      *
      * see method {@link #usage} for details of the command syntax
@@ -65,51 +67,81 @@ public class Install
 
     /**
      * compatability mode
-    * @param pid the process id of the JVM into which the agent should be installed or 0 for this JVM
-    * @param addToBoot true if the agent jar should be installed into the bootstrap classpath
-    * @param host the hostname to be used by the agent listener or null for localhost
-    * @param port the port to be used by the agent listener or 0 for the default port
-    * @param properties an array of System properties to be installed by the agent with optional values e.g.
-    * values such as "org.jboss.byteman.verbose" or "org.jboss.byteman.dump.generated.classes.directory=./dump"
-    * @throws IllegalArgumentException if any of the arguments  is invalid
-    * @throws FileNotFoundException if the agent jar cannot be found using the environment variable BYTEMAN_HOME
-    * or the System property org.jboss.byteman.home and cannot be located in the current classpath
-    * @throws IOException if the byteman jar cannot be opened or uploaded to the requested JVM
-    * @throws AttachNotSupportedException if the requested JVM cannot be attached to
-    * @throws AgentLoadException if an error occurs during upload of the agent into the JVM
-    * @throws AgentInitializationException if the agent fails to initialize after loading. this almost always
-    * indicates that the agent is already loaded into the JVM
+     * @param pid the process id of the JVM into which the agent should be installed or 0 for this JVM
+     * @param addToBoot true if the agent jar should be installed into the bootstrap classpath
+     * @param host the hostname to be used by the agent listener or null for localhost
+     * @param port the port to be used by the agent listener or 0 for the default port
+     * @param properties an array of System properties to be installed by the agent with optional values e.g.
+     * values such as "org.jboss.byteman.verbose" or "org.jboss.byteman.dump.generated.classes.directory=./dump"
+     * @throws IllegalArgumentException if any of the arguments  is invalid
+     * @throws FileNotFoundException if the agent jar cannot be found using the environment variable BYTEMAN_HOME
+     * or the System property org.jboss.byteman.home and cannot be located in the current classpath
+     * @throws IOException if the byteman jar cannot be opened or uploaded to the requested JVM
+     * @throws AttachNotSupportedException if the requested JVM cannot be attached to
+     * @throws AgentLoadException if an error occurs during upload of the agent into the JVM
+     * @throws AgentInitializationException if the agent fails to initialize after loading. this almost always
+     * indicates that the agent is already loaded into the JVM
      */
     public static void install(String pid, boolean addToBoot, String host, int  port, String[] properties)
             throws IllegalArgumentException, FileNotFoundException,
             IOException, AttachNotSupportedException,
             AgentLoadException, AgentInitializationException
     {
-         install(pid, addToBoot, false, host, port, properties);
+        install(pid, addToBoot, false, host, port, properties);
     }
 
-   /**
-    * @param pid the process id of the JVM into which the agent should be installed or 0 for this JVM
-    * @param addToBoot true if the agent jar should be installed into the bootstrap classpath
-    * @param setPolicy true if the agent jar should set an access-all-areas securityPolicy
-    * @param host the hostname to be used by the agent listener or null for localhost
-    * @param port the port to be used by the agent listener or 0 for the default port
-    * @param properties an array of System properties to be installed by the agent with optional values e.g.
-    * values such as "org.jboss.byteman.verbose" or "org.jboss.byteman.dump.generated.classes.directory=./dump"
-    * @throws IllegalArgumentException if any of the arguments  is invalid
-    * @throws FileNotFoundException if the agent jar cannot be found using the environment variable BYTEMAN_HOME
-    * or the System property org.jboss.byteman.home and cannot be located in the current classpath
-    * @throws IOException if the byteman jar cannot be opened or uploaded to the requested JVM
-    * @throws AttachNotSupportedException if the requested JVM cannot be attached to
-    * @throws AgentLoadException if an error occurs during upload of the agent into the JVM
-    * @throws AgentInitializationException if the agent fails to initialize after loading. this almost always
-    * indicates that the agent is already loaded into the JVM
-    */
-   public static void install(String pid, boolean addToBoot, boolean setPolicy, String host, int  port, String[] properties)
-           throws IllegalArgumentException, FileNotFoundException,
-            IOException, AttachNotSupportedException,
-            AgentLoadException, AgentInitializationException
+    /**
+     * compatability mode
+     * @param pid the process id of the JVM into which the agent should be installed or 0 for this JVM
+     * @param addToBoot true if the agent jar should be installed into the bootstrap classpath
+     * @param setPolicy true if the agent jar should set an access-all-areas securityPolicy
+     * @param host the hostname to be used by the agent listener or null for localhost
+     * @param port the port to be used by the agent listener or 0 for the default port
+     * @param properties an array of System properties to be installed by the agent with optional values e.g.
+     * values such as "org.jboss.byteman.verbose" or "org.jboss.byteman.dump.generated.classes.directory=./dump"
+     * @throws IllegalArgumentException if any of the arguments  is invalid
+     * @throws FileNotFoundException if the agent jar cannot be found using the environment variable BYTEMAN_HOME
+     * or the System property org.jboss.byteman.home and cannot be located in the current classpath
+     * @throws IOException if the byteman jar cannot be opened or uploaded to the requested JVM
+     * @throws AttachNotSupportedException if the requested JVM cannot be attached to
+     * @throws AgentLoadException if an error occurs during upload of the agent into the JVM
+     * @throws AgentInitializationException if the agent fails to initialize after loading. this almost always
+     * indicates that the agent is already loaded into the JVM
+     */
+    public static void install(String pid, boolean addToBoot, boolean setPolicy, String host, int  port, String[] properties)
+          throws IllegalArgumentException, FileNotFoundException,
+           IOException, AttachNotSupportedException,
+           AgentLoadException, AgentInitializationException
     {
+       install(pid, addToBoot, setPolicy, false, host, port, properties);
+    }
+       
+    /**
+     * compatability mode
+     * @param pid the process id of the JVM into which the agent should be installed or 0 for this JVM
+     * @param addToBoot true if the agent jar should be installed into the bootstrap classpath
+     * @param setPolicy true if the agent jar should set an access-all-areas securityPolicy
+     * @param useModuleLoader true if the JBoss module loader mode should be configured
+     * @param host the hostname to be used by the agent listener or null for localhost
+     * @param port the port to be used by the agent listener or 0 for the default port
+     * @param properties an array of System properties to be installed by the agent with optional values e.g.
+     * values such as "org.jboss.byteman.verbose" or "org.jboss.byteman.dump.generated.classes.directory=./dump"
+     * @throws IllegalArgumentException if any of the arguments  is invalid
+     * @throws FileNotFoundException if the agent jar cannot be found using the environment variable BYTEMAN_HOME
+     * or the System property org.jboss.byteman.home and cannot be located in the current classpath
+     * @throws IOException if the byteman jar cannot be opened or uploaded to the requested JVM
+     * @throws AttachNotSupportedException if the requested JVM cannot be attached to
+     * @throws AgentLoadException if an error occurs during upload of the agent into the JVM
+     * @throws AgentInitializationException if the agent fails to initialize after loading. this almost always
+     * indicates that the agent is already loaded into the JVM
+     */
+    public static void install(String pid, boolean addToBoot, boolean setPolicy, boolean useModuleLoader, String host, int  port, String[] properties)
+              throws IllegalArgumentException, FileNotFoundException,
+               IOException, AttachNotSupportedException,
+               AgentLoadException, AgentInitializationException
+    {
+       
+       
         if (port < 0) {
             throw new IllegalArgumentException("Install : port cannot be negative");
         }
@@ -124,7 +156,7 @@ public class Install
             }
         }
         
-        Install install = new Install(pid, addToBoot, setPolicy, host, port, properties);
+        Install install = new Install(pid, addToBoot, setPolicy, useModuleLoader, host, port, properties);
         install.locateAgent();
         install.attach();
         install.injectAgent();
@@ -208,19 +240,21 @@ public class Install
      */
     private Install(String pid, boolean addToBoot, String host, int port, String[] properties)
     {
-        this(pid, addToBoot, false, host, port, properties);
+        this(pid, addToBoot, false, false, host, port, properties);
     }
 
     /**
      *  only this class creates instances
      */
-    private Install(String pid, boolean addToBoot, boolean setPolicy, String host, int port, String[] properties)
+    private Install(String pid, boolean addToBoot, boolean setPolicy, boolean useModuleLoader, String host, int port, String[] properties)
     {
         agentJar = null;
+        modulePluginJar = null;
         this.id = pid;
         this.port = port;
         this.addToBoot = addToBoot;
         this.setPolicy = setPolicy;
+        this.useModuleLoader = useModuleLoader;
         this.host = host;
         if (properties != null) {
             StringBuilder builder = new StringBuilder();
@@ -236,7 +270,7 @@ public class Install
     }
 
     /**
-     * check the supplied arguments and stash away te relevant data
+     * check the supplied arguments and stash away the relevant data
      * @param args the value supplied to main
      */
     private void parseArgs(String[] args)
@@ -278,6 +312,9 @@ public class Install
             } else if (nextArg.equals("-s")) {
                 idx++;
                 setPolicy = true;
+            } else if (nextArg.equals("-m")) {
+                idx++;
+                useModuleLoader = true;
             } else if (nextArg.startsWith("-D")) {
                 idx++;
                 String prop=nextArg.substring(2);
@@ -319,13 +356,19 @@ public class Install
             bmHome = System.getenv(BYTEMAN_HOME_ENV_VAR);
         }
         if (bmHome == null || bmHome.length() == 0 || bmHome.equals("null")) {
-            locateAgentFromClasspath();
+            agentJar = locateJarFromClasspath(BYTEMAN_AGENT_NAME);
+            if(useModuleLoader) {
+                modulePluginJar = locateJarFromClasspath(BYTEMAN_MODULES_PLUGIN_NAME);
+            }
         } else {
-            locateAgentFromHomeDir(bmHome);
+            agentJar = locateJarFromHomeDir(bmHome, BYTEMAN_AGENT_BASE_DIR, BYTEMAN_AGENT_NAME);
+            if (useModuleLoader) {
+                modulePluginJar = locateJarFromHomeDir(bmHome, BYTEMAN_MODULES_PLUGIN_BASE_DIR, BYTEMAN_MODULES_PLUGIN_NAME);
+            }
         }
     }
 
-    public void locateAgentFromHomeDir(String bmHome) throws IOException
+    public String locateJarFromHomeDir(String bmHome, String baseDir, String libName) throws IOException
     {
         if (bmHome.endsWith("/")) {
             bmHome = bmHome.substring(0, bmHome.length() - 1);
@@ -336,29 +379,28 @@ public class Install
             throw new FileNotFoundException("Install : " + bmHome + " does not identify a directory");
         }
 
-        File bmLibFile = new File(bmHome + "/lib");
+        File bmLibFile = new File(bmHome + "/" + baseDir);
         if (!bmLibFile.isDirectory()) {
-            throw new FileNotFoundException("Install : " + bmHome + "/lib does not identify a directory");
+            throw new FileNotFoundException("Install : " + bmHome + "/" + baseDir + " does not identify a directory");
         }
 
         try {
-            JarFile bytemanJarFile = new JarFile(bmHome + "/lib/byteman.jar");
+            JarFile jarFile = new JarFile(bmHome + "/" + baseDir + "/" + libName + ".jar");
         } catch (IOException e) {
-            throw new IOException("Install : " + bmHome + "/lib/byteman.jar is not a valid jar file", e);
+            throw new IOException("Install : " + bmHome + "/" + baseDir + "/" + libName + ".jar is not a valid jar file", e);
         }
 
-        agentJar = bmHome + "/lib/byteman.jar";
+        return bmHome + "/" + baseDir + "/" + libName + ".jar";
     }
 
-    public void locateAgentFromClasspath() throws IOException
+    public String locateJarFromClasspath(String libName) throws IOException
     {
         String javaClassPath = System.getProperty("java.class.path");
         String pathSepr = System.getProperty("path.separator");
         String fileSepr = System.getProperty("file.separator");
         final String EXTENSION = ".jar";
         final int EXTENSION_LEN = EXTENSION.length();
-        final String NAME = "byteman";
-        final int NAME_LEN = NAME.length();
+        final int NAME_LEN = libName.length();
         final String VERSION_PATTERN = "-[0-9]+\\.[0-9]+\\.[0-9]+.*";
 
         String[] elements = javaClassPath.split(pathSepr);
@@ -370,7 +412,7 @@ public class Install
                 if (lastFileSepr >= 0) {
                     name= name.substring(lastFileSepr+1);
                 }
-                if (name.startsWith(NAME)) {
+                if (name.startsWith(libName)) {
                     if (name.length() == NAME_LEN) {
                         jarname = element;
                         break;
@@ -387,10 +429,10 @@ public class Install
         }
 
         if (jarname != null) {
-            agentJar = jarname;
-            System.out.println("byteman jar is " + jarname);
+            System.out.println(libName + " jar is " + jarname);
+            return jarname;
         } else {
-            throw new  FileNotFoundException("Install : cannot find Byteman agent jar please set environment variable " + BYTEMAN_HOME_ENV_VAR + " or System property " + BYTEMAN_HOME_SYSTEM_PROP);
+            throw new  FileNotFoundException("Install : cannot find " + libName + " jar please set environment variable " + BYTEMAN_HOME_ENV_VAR + " or System property " + BYTEMAN_HOME_SYSTEM_PROP);
         }
     }
 
@@ -472,6 +514,9 @@ public class Install
             if (setPolicy) {
                 agentOptions += ",policy:true";
             }
+            if (useModuleLoader) {
+                agentOptions += ",modules:org.jboss.byteman.modules.jbossmodules.JBossModulesSystem,sys:" + modulePluginJar;
+            }
             if (props != null) {
                 agentOptions += props;
             }
@@ -488,25 +533,29 @@ public class Install
      */
     private static void usage(int exitValue)
     {
-        System.out.println("usage : Install [-h host] [-p port] [-b] [-Dprop[=value]]* pid");
+        System.out.println("usage : Install [-h host] [-p port] [-b] [-s] [-m] [-Dprop[=value]]* pid");
         System.out.println("        upload the byteman agent into a running JVM");
         System.out.println("    pid is the process id of the target JVM or the unique name of the process as reported by the jps -l command");
         System.out.println("    -h host selects the host name or address the agent listener binds to");
         System.out.println("    -p port selects the port the agent listener binds to");
         System.out.println("    -b adds the byteman jar to the bootstrap classpath");
         System.out.println("    -s sets an access-all-areas security policy for the Byteman agent code");
+        System.out.println("    -m activates the byteman JBoss modules plugin");
         System.out.println("    -Dname=value can be used to set system properties whose name starts with \"org.jboss.byteman.\"");
         System.out.println("    expects to find a byteman agent jar in ${" + BYTEMAN_HOME_ENV_VAR + "}/lib/byteman.jar");
+        System.out.println("    and JBoss modules plugin jar (if -m option is enabled)  in ${" + BYTEMAN_HOME_ENV_VAR + "}/contrib/jboss-modules-system/byteman-jboss-modules-plugin.jar");
         System.out.println("    (alternatively set System property " + BYTEMAN_HOME_SYSTEM_PROP + " to overide ${" + BYTEMAN_HOME_ENV_VAR + "})");
         System.exit(exitValue);
     }
 
     private String agentJar;
+    private String modulePluginJar;
     private String id;
     private int port;
     private String host;
     private boolean addToBoot;
     private boolean setPolicy;
+    private boolean useModuleLoader;
     private String props;
     private VirtualMachine vm;
 
@@ -523,4 +572,24 @@ public class Install
      * environment variable used to idenitfy the location of the installed byteman release.
      */
     private static final String BYTEMAN_HOME_ENV_VAR = "BYTEMAN_HOME";
+    
+    /**
+     * Base directory to look for agent jar.
+     */
+    private static final String BYTEMAN_AGENT_BASE_DIR = "lib";
+
+    /**
+     * Name of agent jar (without extension).
+     */
+    private static final String BYTEMAN_AGENT_NAME = "byteman";
+    
+    /**
+     * Base directory to look for JBoss modules plugin jar.
+     */
+    private static final String BYTEMAN_MODULES_PLUGIN_BASE_DIR = "contrib/jboss-modules-system";
+
+    /**
+     * Name of JBoss modules plugin jar (without extension). 
+     */
+    private static final String BYTEMAN_MODULES_PLUGIN_NAME = "byteman-jboss-modules-plugin";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         into Java application and JVM runtime methods. Its primary purpose is to support execution tracing and fault
         injection testing.
     </description>
-    <version>3.0.8</version>
+    <version>3.0.9-SNAPSHOT</version>
     <name>byteman-root</name>
     <url>http://www.jboss.org/byteman</url>
 

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
     </parent>
     <description>
         The Byteman sample jar contains some example helper classes and auxiliary classes used by the]

--- a/submit/pom.xml
+++ b/submit/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-root</artifactId>
-        <version>3.0.8</version>
+        <version>3.0.9-SNAPSHOT</version>
     </parent>
     <build>
       <plugins>


### PR DESCRIPTION
[CHG] byteman-jboss-modules-plugin also works now with older versions of
jboss-modules (1.2.0) that use protected constructors for ModuleLoader
[NEW] byteman-install now accepts "-m" option to enable JBoss module
plugin
[CHG] Modified versions to 3.0.9-SNAPSHOT