### PR TITLE
[BYTEMAN-345] dtest instrument instance concurrency fail

### DIFF
--- a/contrib/dtest/src/main/java/org/jboss/byteman/contrib/dtest/InstrumentedInstance.java
+++ b/contrib/dtest/src/main/java/org/jboss/byteman/contrib/dtest/InstrumentedInstance.java
@@ -20,10 +20,9 @@
  */
 package org.jboss.byteman.contrib.dtest;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.Assert.assertTrue;
+
+import java.util.Queue;
 
 /**
  * InstrumentedInstance instances serve two purposes:
@@ -40,7 +39,7 @@ public class InstrumentedInstance
 {
     private final String className;
     private final Integer instanceId;
-    private final List<String> methodTraces = new ArrayList<String>();
+    private final Queue<String> methodTraces = new java.util.concurrent.ConcurrentLinkedQueue<String>();
 
     InstrumentedInstance(String className, Integer instanceId)
     {

--- a/contrib/dtest/src/main/java/org/jboss/byteman/contrib/dtest/Instrumentor.java
+++ b/contrib/dtest/src/main/java/org/jboss/byteman/contrib/dtest/Instrumentor.java
@@ -141,7 +141,20 @@ public class Instrumentor
      */
     public InstrumentedClass instrumentClass(Class clazz) throws Exception
     {
-        return instrumentClass(clazz, null);
+        Set<String> nullSet = null;
+        return instrumentClass(clazz, nullSet);
+    }
+
+    public InstrumentedClass instrumentClass(Class clazz, String... methodNames) throws Exception
+    {
+        if (methodNames ==null)
+        {
+            Set<String> nullSet = null;
+            return instrumentClass(clazz, nullSet);
+        } else
+        {
+            return instrumentClass(clazz, new HashSet<String>(Arrays.asList(methodNames)));
+        }
     }
 
     /**
@@ -167,6 +180,14 @@ public class Instrumentor
         }
 
         return instrumentClass(className, methodNamesToInstrument);
+    }
+
+    /**
+     * See {@link #instrumentClass(String, Set)}
+     */
+    public InstrumentedClass instrumentClass(String className, String... methodNames) throws Exception
+    {
+        return instrumentClass(className, new HashSet<String>(Arrays.asList(methodNames)));
     }
 
     /**


### PR DESCRIPTION
* small enhancement of `Instrumentor` api when instrumenting a class with specific methods
* using concurrent util queue instead of list to fix a concurrency issue when multiple trace calls are called in parallel to client