### PR TITLE
Allow building the documentation on JDK9

### DIFF
--- a/docs/asciidoc/pom.xml
+++ b/docs/asciidoc/pom.xml
@@ -14,8 +14,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-    <jruby.version>1.7.17</jruby.version>
+    <asciidoctor.maven.plugin.version>1.5.6</asciidoctor.maven.plugin.version>
+    <asciidoctorj.version>1.5.6</asciidoctorj.version>
+    <asciidoctorj-pdf.version>1.5.0-alpha.16</asciidoctorj-pdf.version>
+    <jruby.version>9.1.15.0</jruby.version>
 
     <maven.build.timestamp.format>MMM dd, yyyy</maven.build.timestamp.format>
   </properties>
@@ -27,12 +29,21 @@
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
         <version>${asciidoctor.maven.plugin.version}</version>
-
         <dependencies>
+          <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby-complete</artifactId>
+            <version>${jruby.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>${asciidoctorj.version}</version>
+          </dependency>
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
-            <version>1.5.0-alpha.6</version>
+            <version>${asciidoctorj-pdf.version}</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
Resolving: https://issues.jboss.org/browse/BYTEMAN-356

It was a bit annoying that the documentation would fail the build, as it doesn't build on JDK9 - while other modules now require JDK9.

Merging this should make it possible to run the full build, as long as Java 9 is being used of course.
