### PR TITLE
Allow for scripts to respect JAVA_HOME

### DIFF
--- a/bin/bmcheck.sh
+++ b/bin/bmcheck.sh
@@ -25,6 +25,12 @@
 #
 # usage: bmcheck [-cp classpath]* [-p package]* [-v] script1 . . . scriptN
 #
+# use JAVA_HOME for the java binary unless JAVA_HOME is not specified
+JAVA=java
+if [ ! -z "$JAVA_HOME" ]; then
+    JAVA=$JAVA_HOME/bin/java
+fi
+#
 # use BYTEMAN_HOME to locate installed byteman release
 if [ -z "$BYTEMAN_HOME" ]; then
 # use the root of the path to this file to locate the byteman jar
@@ -103,4 +109,4 @@ fi
 
 # allow for extra java opts via setting BYTEMAN_JAVA_OPTS
 
-java ${BYTEMAN_JAVA_OPTS} -classpath "${CP}" $DEFINES org.jboss.byteman.check.TestScript $PACKAGES $VERBOSE $FILES
+${JAVA} ${BYTEMAN_JAVA_OPTS} -classpath "${CP}" $DEFINES org.jboss.byteman.check.TestScript $PACKAGES $VERBOSE $FILES

--- a/bin/bminstall.sh
+++ b/bin/bminstall.sh
@@ -36,12 +36,18 @@
 #   expects to find a byteman agent jar and byteman JBoss modules plugin jar (if -m is indicated) in BYTEMAN_HOME
 #
 
+# use JAVA_HOME for the java binary unless, JAVA_HOME is not specified
+JAVA=java
+if [ ! -z "$JAVA_HOME" ]; then
+    JAVA=$JAVA_HOME/bin/java
+fi
+
 # helper function to obtain java version
 function print_java_version()
 {
     typeset -l java_version
     # grep output for line : 'java/openjdk version "AAAAAAAA"' where A is alpha, num, '''. or '-'
-    java_version=`java -version 2>&1 |  grep "version" | cut -d'"' -f2`
+    java_version=`$JAVA -version 2>&1 |  grep "version" | cut -d'"' -f2`
     # format for JDK8- is 1.N.[n_]+
     if [ ${java_version%%.*} == 1 ] ; then
         echo $java_version | cut -d'.' -f2
@@ -120,4 +126,4 @@ fi
 # allow for extra java opts via setting BYTEMAN_JAVA_OPTS
 # attach class will validate arguments
 
-java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
+$JAVA ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*

--- a/bin/bmjava.sh
+++ b/bin/bmjava.sh
@@ -52,10 +52,16 @@
 #   javaargs trailing arguments to be supplied to the java command
 #
 # The script employs the java command found in the current execution
-# PATH. If BYTEMAN_JAVA_ARGS is set then this is inserted to the
-# java command line before the -javaagent argument and before any
-# arguments in javaargs.
+# PATH (or the java version found via JAVA_HOME). If BYTEMAN_JAVA_ARGS
+# is set then this is inserted to the java command line before the
+# -javaagent argument and before any arguments in javaargs.
 #
+
+# use JAVA_HOME for the java binary unless JAVA_HOME is not specified
+JAVA=java
+if [ ! -z "$JAVA_HOME" ]; then
+    JAVA=$JAVA_HOME/bin/java
+fi
 
 usage()
 {
@@ -225,5 +231,5 @@ AGENT_ARGUMENT=${AGENT_PREFIX}=${AGENT_OPTS}
 # allow for extra java opts via setting BYTEMAN_JAVA_OPTS
 
 set -x
-exec java ${BYTEMAN_JAVA_OPTS} "${AGENT_ARGUMENT}" ${INJECT_JAVA_LANG_OPTS} $*
+exec $JAVA ${BYTEMAN_JAVA_OPTS} "${AGENT_ARGUMENT}" ${INJECT_JAVA_LANG_OPTS} $*
 

--- a/bin/bmsubmit.sh
+++ b/bin/bmsubmit.sh
@@ -51,6 +51,12 @@
 #
 #   -v print the version of the byteman agent and this client
 #
+# use JAVA_HOME for the java binary unless JAVA_HOME is not specified
+JAVA=java
+if [ ! -z "$JAVA_HOME" ]; then
+    JAVA=$JAVA_HOME/bin/java
+fi
+#
 # use BYTEMAN_HOME to locate installed byteman release
 if [ -z "$BYTEMAN_HOME" ]; then
 # use the root of the path to this file to locate the byteman jar
@@ -81,4 +87,4 @@ fi
 # allow for extra java opts via setting BYTEMAN_JAVA_OPTS
 # Submit class will validate arguments
 
-java ${BYTEMAN_JAVA_OPTS} -classpath "${BYTEMAN_JAR}":"${BYTEMAN_SUBMIT_JAR}" org.jboss.byteman.agent.submit.Submit $*
+$JAVA ${BYTEMAN_JAVA_OPTS} -classpath "${BYTEMAN_JAR}":"${BYTEMAN_SUBMIT_JAR}" org.jboss.byteman.agent.submit.Submit $*

--- a/bin/bytemancheck.sh
+++ b/bin/bytemancheck.sh
@@ -25,6 +25,12 @@
 #
 # usage: bytemancheck [-cp classpath]* [-p package]* [-v] script1 . . . scriptN
 #
+# use JAVA_HOME for the java binary unless JAVA_HOME is not specified
+JAVA=java
+if [ ! -z "$JAVA_HOME" ]; then
+    JAVA=$JAVA_HOME/bin/java
+fi
+#
 # use BYTEMAN_HOME to locate installed byteman release
 if [ -z "$BYTEMAN_HOME" ]; then
 # use the root of the path to this file to locate the byteman jar
@@ -103,4 +109,4 @@ fi
 
 # allow for extra java opts via setting BYTEMAN_JAVA_OPTS
 
-java ${BYTEMAN_JAVA_OPTS} -classpath "${CP}" $DEFINES org.jboss.byteman.check.TestScript $PACKAGES $VERBOSE $FILES
+${JAVA} ${BYTEMAN_JAVA_OPTS} -classpath "${CP}" $DEFINES org.jboss.byteman.check.TestScript $PACKAGES $VERBOSE $FILES


### PR DESCRIPTION
Sometimes a user might have multiple JDKs
installed. It's rather customary to set
JAVA_HOME to the JDK which should be used.

However, bm* scripts don't look in
JAVA_HOME but in the PATH only. With this
patch one can set JAVA_HOME and be sure
that bm* scripts will use the java binary
from JAVA_HOME.