### PR TITLE
[BYTEMAN-398] Check the entry point class loader before using to the …

### DIFF
--- a/agent/src/main/java/org/jboss/byteman/agent/Main.java
+++ b/agent/src/main/java/org/jboss/byteman/agent/Main.java
@@ -250,7 +250,10 @@ public class Main {
         // resolve against the system loader and injection into bootstrap classes fails. But that's still ok
         // because the byteman classes are still only found in one place.
 
-        ClassLoader loader = ClassLoader.getSystemClassLoader();
+        ClassLoader loader = Main.class.getClassLoader();
+        if (loader == null) {
+            loader = ClassLoader.getSystemClassLoader();
+        }
 
         if (moduleSystemName == null) {
             moduleSystemName = "org.jboss.byteman.modules.NonModuleSystem";


### PR DESCRIPTION
…system class loader.

https://issues.redhat.com/browse/BYTEMAN-398

The JIRA has some details on why I was testing this. If this is bad practice please feel free to close this PR.

A side note I noticed master is still using version `4.0.11` which has been released so there might be a missing commit to bump it to `4.0.12-SNAPSHOT`.