### PR TITLE
add jbang-catalog

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,9 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "byteman": {
+      "script-ref": "org.jboss.byteman:byteman:RELEASE"
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
enables `jbang --javaagent=byteman@bytemanproject/byteman ...`

note, I recommend instead of merging this you create https://github.com/bytemanproject/jbang-catalog so `jbang byteman@bytemanproject` is sufficient