### PR TITLE
Fix BMUnit resource-based script lookup

### DIFF
--- a/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnit.java
+++ b/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnit.java
@@ -335,7 +335,11 @@ public class BMUnit
         } else {
             // n.b. defaults either are "" or end with correct separator
             filename = normalize(getLoadDirectory(), true) + filename;
-            resourceName = normalize(getResourceLoadDirectory(), true) + filename;
+            String resourceDir = getResourceLoadDirectory();
+            if(resourceDir != null && resourceDir.length() > 0) {
+                String separator = resourceDir.endsWith("/") ? "" : "/";
+                resourceName = resourceDir + separator + resourceName;
+            }
         }
 
         final String[] filenames={filename, filename + ".btm", filename + ".txt"};
@@ -347,11 +351,11 @@ public class BMUnit
                 return fname;
         }
 
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            loader = ClassLoader.getSystemClassLoader();
+        }
         for(String rname: resourceNames) {
-	    ClassLoader loader = Thread.currentThread().getContextClassLoader();
-	    if (loader == null) {
-                loader = ClassLoader.getSystemClassLoader();
-            }
             URL resource=loader.getResource(rname);
             if(resource != null) {
                 File file=new File(resource.getFile());

--- a/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnitConfigState.java
+++ b/contrib/bmunit/src/org/jboss/byteman/contrib/bmunit/BMUnitConfigState.java
@@ -836,7 +836,7 @@ public class BMUnitConfigState
     public String getLoadDirectory() {
         // loadDirectory can be overridden so don't look up previous
         // unless it is empty or null
-        if ((loadDirectory != null || loadDirectory.length() == 0) && previous != null) {
+        if ((loadDirectory == null || loadDirectory.length() == 0) && previous != null) {
             return previous.getLoadDirectory();
         }
         return loadDirectory;
@@ -849,7 +849,7 @@ public class BMUnitConfigState
     public String getResourceLoadDirectory() {
         // loadDirectory can be overridden so don't look up previous
         // unless it is empty or null
-        if ((resourceLoadDirectory != null || resourceLoadDirectory.length() == 0) && previous != null) {
+        if ((resourceLoadDirectory == null || resourceLoadDirectory.length() == 0) && previous != null) {
             return previous.getResourceLoadDirectory();
         }
         return resourceLoadDirectory;


### PR DESCRIPTION
The original lookup logic involved function `normalize` which is intended for file-system path manipulation. On Windows this means that all path components are separated by a backslash; however such paths are not usable in `Classloader.getResource()`. The logic was fixed to use `/` for resource path construction.

In addition, it appears that methods `getLoadDirectory` and `getResourceLoadDirectory` in `org.jboss.byteman.contrib.bmunit.BMUnitConfigState` did incorrectly determine whether to do a chained lookup, contradicting associated comments and possibly causing NullPointerException. The respective conditions were fixed.